### PR TITLE
clock: add B2Clock to abstract time sources.

### DIFF
--- a/core/src/main/java/com/backblaze/b2/client/B2ByteProgressFilteringListener.java
+++ b/core/src/main/java/com/backblaze/b2/client/B2ByteProgressFilteringListener.java
@@ -55,14 +55,14 @@ class B2ByteProgressFilteringListener implements B2ByteProgressListener {
     public void progress(long nBytesSoFar) {
         this.bytesSoFar = nBytesSoFar;
 
-        final long nowMsecs = B2Clock.get().getNowMsecTime();
+        final long monoMsecs = B2Clock.get().getMonoMsecTime();
 
         // only send if enough time has gone by.
-        if (nowMsecs >= msecsThreshold) {
+        if (monoMsecs >= msecsThreshold) {
             listener.progress(nBytesSoFar);
 
             // reset threshold for next send.
-            msecsThreshold = nowMsecs + nMsecsBetween;
+            msecsThreshold = monoMsecs + nMsecsBetween;
         }
     }
 

--- a/core/src/main/java/com/backblaze/b2/client/B2ByteProgressFilteringListener.java
+++ b/core/src/main/java/com/backblaze/b2/client/B2ByteProgressFilteringListener.java
@@ -5,6 +5,7 @@
 package com.backblaze.b2.client;
 
 import com.backblaze.b2.util.B2ByteProgressListener;
+import com.backblaze.b2.util.B2Clock;
 
 import static com.backblaze.b2.util.B2DateTimeUtil.ONE_SECOND_IN_MSECS;
 
@@ -37,8 +38,8 @@ class B2ByteProgressFilteringListener implements B2ByteProgressListener {
      * @param listener the listener to forward notifications to.
      * @param nMsecsBetween if this much time has passed since previous progress() was forwarded, forward it.
      */
-    B2ByteProgressFilteringListener(B2ByteProgressListener listener,
-                                    long nMsecsBetween) {
+    private B2ByteProgressFilteringListener(B2ByteProgressListener listener,
+                                            long nMsecsBetween) {
         this.listener = listener;
         this.nMsecsBetween = nMsecsBetween;
     }
@@ -54,7 +55,7 @@ class B2ByteProgressFilteringListener implements B2ByteProgressListener {
     public void progress(long nBytesSoFar) {
         this.bytesSoFar = nBytesSoFar;
 
-        final long nowMsecs = System.currentTimeMillis();
+        final long nowMsecs = B2Clock.get().getNowMsecTime();
 
         // only send if enough time has gone by.
         if (nowMsecs >= msecsThreshold) {

--- a/core/src/main/java/com/backblaze/b2/client/B2RetryPolicy.java
+++ b/core/src/main/java/com/backblaze/b2/client/B2RetryPolicy.java
@@ -12,7 +12,7 @@ import com.backblaze.b2.client.exceptions.B2Exception;
  * the number of milliseconds the call took (tookMs).  For unsuccessful
  * attempts, it is also passed the exception which caused the failure.
  *
- * For each of the getRetryable*() methods, the guide is consulted to decide
+ * For each of the getRetryable*() methods, the policy is consulted to decide
  * whether (and when) to retry.
  *
  * By the way, attemptsSoFar starts at 1.

--- a/core/src/main/java/com/backblaze/b2/util/B2Clock.java
+++ b/core/src/main/java/com/backblaze/b2/util/B2Clock.java
@@ -4,6 +4,8 @@
  */
 package com.backblaze.b2.util;
 
+import java.time.LocalDateTime;
+
 /**
  * This class provides access to two different time measurements.
  *
@@ -33,6 +35,25 @@ public abstract class B2Clock {
         B2Preconditions.checkState(theClock == null, "can't change clocks!");
         B2Preconditions.checkArgumentIsNotNull(clock, "clock");
         theClock = clock;
+    }
+
+    /**
+     * If theClock is null, this will create a B2ClockSim with the desiredNow.
+     * If theClock is a B2ClockSim, this will set it to the specified time.
+     * If theclock is not a B2ClockSim, this will throw.
+     * @param desiredNow is the wall clock time for the simulator's "now".
+     * @return theClock
+     */
+    public static B2ClockSim useSimulator(LocalDateTime desiredNow) {
+        if (theClock == null) {
+            theClock = new B2ClockSim(desiredNow);
+        }
+        B2Preconditions.checkState(theClock instanceof B2ClockSim,
+                "theClock must be a B2ClockSim, but it's a " + theClock.getClass().getSimpleName());
+
+        final B2ClockSim sim = (B2ClockSim) theClock;
+        sim.resetBoth(desiredNow);
+        return sim;
     }
 
     /**

--- a/core/src/main/java/com/backblaze/b2/util/B2Clock.java
+++ b/core/src/main/java/com/backblaze/b2/util/B2Clock.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017, Backblaze Inc. All Rights Reserved.
+ * License https://www.backblaze.com/using_b2_code.html
+ */
+package com.backblaze.b2.util;
+
+/**
+ * This class provides access to two different time measurements.
+ *
+ * It also provides access to the global clock object.  It's an object
+ * instead of static methods so we can use a different implementation
+ * in tests.
+ *
+ * It is an abstract class instead of an interface so that it can hold the
+ * global instance. (If we had a dependency injection system we would
+ * probably use that instead of a global, but we don't have one.)
+ *
+ * I also keep thinking that maybe there should be two different types
+ * of clock objects -- one for monotonic time and one for wall clock time.
+ * So far, I'm keeping them together because it helps to advance them
+ * both in tests and every call to get a value says what type of time it is.
+ */
+public abstract class B2Clock {
+    // only access with while synchronized(B2Clock.class).
+    private static B2Clock theClock;
+
+    /**
+     * This can be used in tests to set theClock to a mock or simulator clock.
+     * It must not be called after get() has been called.
+     * @param clock the clock to use.
+     */
+    public static synchronized void set(B2Clock clock) {
+        B2Preconditions.checkState(theClock == null, "can't change clocks!");
+        B2Preconditions.checkArgumentIsNotNull(clock, "clock");
+        theClock = clock;
+    }
+
+    /**
+     * @return theClock to use.
+     */
+    public static synchronized B2Clock get() {
+        if (theClock == null) {
+            theClock = new B2ClockImpl();
+        }
+        return theClock;
+    }
+
+    /**
+     * @return a monotonically increasing number of nanoseconds.  note that it has
+     *         no relationship to wall clock time and will differ between different
+     *         runs of the JVM.  note that it won't necessarily be as precise as
+     *         nanoseconds.  See System.nanoTime().
+     *
+     *         It is monotonically increasing!
+     *         AND it won't wrap during any single run of a JVM.
+     *         (unless the JVM runs for hundreds of thousands of millenia!
+     *         (2^63 nanos) / (2^9 nanos/sec) / 86400 (secs/day) / 365 (days/year) / 1000 (years/millenia) ~= 571,232 millenia)
+     */
+    public abstract long getMonoNanoTime();
+
+    /**
+     * @return This is just a milliseconds version of getMonoNanoTime().
+     */
+    public long getMonoMsecTime() {
+        return getMonoNanoTime() / B2DateTimeUtil.ONE_MSEC_IN_NANOS;
+    }
+
+    /**
+     * @return the number of milliseconds since the unix epoch.
+     *         may be negative if now is before the epoch.
+     *         the values returned by this represent wall clock
+     *         time and might not be monotonic if the system clock
+     *         is changed.  time might sometimes flow at a variable
+     *         speed or even backwards if the clock is being adjusted.
+     */
+    public abstract long getNowMsecTime();
+}

--- a/core/src/main/java/com/backblaze/b2/util/B2Clock.java
+++ b/core/src/main/java/com/backblaze/b2/util/B2Clock.java
@@ -27,17 +27,6 @@ public abstract class B2Clock {
     private static B2Clock theClock;
 
     /**
-     * This can be used in tests to set theClock to a mock or simulator clock.
-     * It must not be called after get() has been called.
-     * @param clock the clock to use.
-     */
-    public static synchronized void set(B2Clock clock) {
-        B2Preconditions.checkState(theClock == null, "can't change clocks!");
-        B2Preconditions.checkArgumentIsNotNull(clock, "clock");
-        theClock = clock;
-    }
-
-    /**
      * If theClock is null, this will create a B2ClockSim with the desiredNow.
      * If theClock is a B2ClockSim, this will set it to the specified time.
      * If theclock is not a B2ClockSim, this will throw.
@@ -74,8 +63,8 @@ public abstract class B2Clock {
      *
      *         It is monotonically increasing!
      *         AND it won't wrap during any single run of a JVM.
-     *         (unless the JVM runs for hundreds of thousands of millenia!
-     *         (2^63 nanos) / (2^9 nanos/sec) / 86400 (secs/day) / 365 (days/year) / 1000 (years/millenia) ~= 571,232 millenia)
+     *         (unless the JVM runs for hundreds of of years!
+     *         (2^63 nanos) / (10^9 nanos/sec) / (86400 secs/day) / (365 days/year) ~= 292 years)
      */
     public abstract long getMonoNanoTime();
 

--- a/core/src/main/java/com/backblaze/b2/util/B2ClockImpl.java
+++ b/core/src/main/java/com/backblaze/b2/util/B2ClockImpl.java
@@ -16,7 +16,7 @@ public class B2ClockImpl extends B2Clock {
      */
     private final long monoNanoBase;
 
-    B2ClockImpl() {
+    public B2ClockImpl() {
          monoNanoBase = System.nanoTime();
     }
 

--- a/core/src/main/java/com/backblaze/b2/util/B2ClockImpl.java
+++ b/core/src/main/java/com/backblaze/b2/util/B2ClockImpl.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017, Backblaze Inc. All Rights Reserved.
+ * License https://www.backblaze.com/using_b2_code.html
+ */
+package com.backblaze.b2.util;
+
+/**
+ * B2ClockImpl uses values from the System class to provide a "real"
+ * implementation of B2Clock whose clocks are determined by the system.
+ */
+public class B2ClockImpl extends B2Clock {
+    /**
+     * 'monoNanoBase is the first nanoTime we get from the system.
+     * We use it as a baseline to avoid wrapping the monoNanoTime
+     * we return.
+     */
+    private final long monoNanoBase;
+
+    B2ClockImpl() {
+         monoNanoBase = System.nanoTime();
+    }
+
+    @Override
+    public long getMonoNanoTime() {
+        // subtraction gets the right value even if nanoTime() has wrapped past Long.MAX_VALUE.
+        return System.nanoTime() - monoNanoBase;
+    }
+
+    @Override
+    public long getNowMsecTime() {
+        return System.currentTimeMillis();
+    }
+}

--- a/core/src/main/java/com/backblaze/b2/util/B2ClockSim.java
+++ b/core/src/main/java/com/backblaze/b2/util/B2ClockSim.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017, Backblaze Inc. All Rights Reserved.
+ * License https://www.backblaze.com/using_b2_code.html
+ */
+package com.backblaze.b2.util;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+/**
+ * B2ClockSim provides a simple
+ */
+public class B2ClockSim extends B2Clock {
+
+    private long nowMillis;
+    private long nanos;
+
+    private B2ClockSim(long startTimeMillis) {
+        this.nowMillis = startTimeMillis;
+        this.nanos = 0;
+    }
+
+    public static B2ClockSim create(LocalDateTime startTime) {
+        return new B2ClockSim(B2DateTimeUtil.getMillisecondsSinceEpoch(startTime));
+    }
+
+    @Override
+    public long getMonoNanoTime() {
+        return nanos;
+    }
+
+    @Override
+    public long getNowMsecTime() {
+        return nowMillis;
+    }
+
+    /**
+     * Shifts the current time by the given duration.
+     *    the nowMillisTime and monoNanoTime will go forward by the same amount (mod resolution!)
+     * @param delta the amount of time to shift both clocks by.
+     *              must be non-negative to avoid making the monotonic clock go backwards!
+     */
+    public void advanceBoth(Duration delta) {
+        B2Preconditions.checkArgument(delta.toNanos() >= 0, "delta must be non-negative");
+        nowMillis += delta.toMillis();
+        nanos += delta.toNanos();
+    }
+
+    /**
+     * Shifts the current wall clock time by the given duration.
+     * Only nowMills will be adjusted.  Use this when you want to
+     * shift time backwards, since you're not allowed to call advanceBoth()
+     * with negative value.
+     * @param delta the time to advance the wall clock by
+     */
+    public void advanceNow(Duration delta) {
+        nowMillis += delta.toMillis();
+    }
+
+}

--- a/core/src/main/java/com/backblaze/b2/util/B2ClockSim.java
+++ b/core/src/main/java/com/backblaze/b2/util/B2ClockSim.java
@@ -7,6 +7,8 @@ package com.backblaze.b2.util;
 import java.time.Duration;
 import java.time.LocalDateTime;
 
+import static com.backblaze.b2.util.B2DateTimeUtil.getMillisecondsSinceEpoch;
+
 /**
  * B2ClockSim provides a simple
  */
@@ -15,13 +17,8 @@ public class B2ClockSim extends B2Clock {
     private long nowMillis;
     private long nanos;
 
-    private B2ClockSim(long startTimeMillis) {
-        this.nowMillis = startTimeMillis;
-        this.nanos = 0;
-    }
-
-    public static B2ClockSim create(LocalDateTime startTime) {
-        return new B2ClockSim(B2DateTimeUtil.getMillisecondsSinceEpoch(startTime));
+    B2ClockSim(LocalDateTime startTime) {
+        resetBoth(startTime);
     }
 
     @Override
@@ -57,4 +54,14 @@ public class B2ClockSim extends B2Clock {
         nowMillis += delta.toMillis();
     }
 
+    /**
+     * This is intended to be run between tests to reset the clock to an initial
+     * state, as if the simulator has just be constructed.
+     *
+     * @param desiredNow the desired wall clock time.
+     */
+    public void resetBoth(LocalDateTime desiredNow) {
+        this.nowMillis = getMillisecondsSinceEpoch(desiredNow);
+        this.nanos = 0;
+    }
 }

--- a/core/src/main/java/com/backblaze/b2/util/B2DateTimeUtil.java
+++ b/core/src/main/java/com/backblaze/b2/util/B2DateTimeUtil.java
@@ -23,7 +23,7 @@ public class B2DateTimeUtil {
     static final long ONE_HOUR_IN_MSECS = ONE_HOUR_IN_SECONDS * ONE_SECOND_IN_MSECS;
     static final long ONE_DAY_IN_MSECS = ONE_DAY_IN_SECONDS * ONE_SECOND_IN_MSECS;
 
-    static final int ONE_SECOND_IN_NANOS = 1000000000;
+    static final long ONE_SECOND_IN_NANOS = 1000000000;
     static final long ONE_MSEC_IN_NANOS = ONE_SECOND_IN_NANOS / ONE_SECOND_IN_MSECS;
 
 

--- a/core/src/main/java/com/backblaze/b2/util/B2DateTimeUtil.java
+++ b/core/src/main/java/com/backblaze/b2/util/B2DateTimeUtil.java
@@ -18,6 +18,15 @@ public class B2DateTimeUtil {
     static final long ONE_HOUR_IN_SECONDS = 60 * ONE_MINUTE_IN_SECONDS;
     static final long ONE_DAY_IN_SECONDS = 24 * ONE_HOUR_IN_SECONDS;
 
+    public static final long ONE_SECOND_IN_MSECS = 1000;
+    static final long ONE_MINUTE_IN_MSECS = ONE_MINUTE_IN_SECONDS * ONE_SECOND_IN_MSECS;
+    static final long ONE_HOUR_IN_MSECS = ONE_HOUR_IN_SECONDS * ONE_SECOND_IN_MSECS;
+    static final long ONE_DAY_IN_MSECS = ONE_DAY_IN_SECONDS * ONE_SECOND_IN_MSECS;
+
+    static final int ONE_SECOND_IN_NANOS = 1000000000;
+    static final long ONE_MSEC_IN_NANOS = ONE_SECOND_IN_NANOS / ONE_SECOND_IN_MSECS;
+
+
     public static final int MIN_YEAR = 1970;
     public static final int MAX_YEAR = 2999;
 
@@ -36,7 +45,10 @@ public class B2DateTimeUtil {
     private static final int MIN_SECOND = 0;
     private static final int MAX_SECOND = 59; // no leap seconds in Java time
 
-    public static final long ONE_SECOND_IN_MSECS = 1000;
+
+    //private static LocalDate EPOCH = LocalDate.of(1970, 1, 1);
+    static LocalDateTime EPOCH_TIME = LocalDateTime.of(1970, 1, 1, 0, 0);
+
 
     /**
      * Formats a date in "solid" format, like "20150314"
@@ -246,6 +258,15 @@ public class B2DateTimeUtil {
             s = "-" + s;
         }
         return s;
+    }
+
+    /**
+     * Returns the number of milliseconds since 1970-01-01 00:00:00.
+     */
+    static long getMillisecondsSinceEpoch(LocalDateTime dateTime) {
+        // we have to use EPOCH_TIME instead of EPOCH because LocalDate
+        // doesn't support ChronoUnit.SECONDS.
+        return Duration.between(EPOCH_TIME, dateTime).toMillis();
     }
 
     // this exists so it can be called for code coverage purposes in the unit test.

--- a/core/src/test/java/com/backblaze/b2/client/B2ByteProgressFilteringListenerTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2ByteProgressFilteringListenerTest.java
@@ -1,0 +1,115 @@
+package com.backblaze.b2.client;/*
+ * Copyright 2017, Backblaze, Inc. All rights reserved. 
+ */
+
+import com.backblaze.b2.util.B2ByteProgressListener;
+import com.backblaze.b2.util.B2Clock;
+import com.backblaze.b2.util.B2ClockSim;
+import org.junit.After;
+import org.junit.Test;
+
+import java.time.Duration;
+
+import static com.backblaze.b2.util.B2DateTimeUtil.parseDateTime;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class B2ByteProgressFilteringListenerTest {
+    private final B2ClockSim clockSim = B2Clock.useSimulator(parseDateTime("2017-08-31 00:00:00"));
+    private final B2ByteProgressListener wrapped = mock(B2ByteProgressListener.class);
+    private final B2ByteProgressListener filtering = new B2ByteProgressFilteringListener(wrapped);
+    private final Exception exception = new RuntimeException("intentional");
+
+    @After
+    public void shutdown() {
+        verifyNoMoreInteractions(wrapped);
+    }
+
+    @Test
+    public void test() {
+        long bytesSoFar = 100;
+
+
+        checkReachedEofAndException(bytesSoFar);
+        checkProgressCalled(bytesSoFar); // the first progress should be called
+
+        // let a little time and bytes pass.  too soon for progress()
+        {
+            bytesSoFar += 1;
+            clockSim.advanceBoth(Duration.ofMillis(4900));
+            assertEquals(4900, clockSim.getMonoMsecTime());
+
+            checkReachedEofAndException(bytesSoFar);
+            checkProgressNotCalled(bytesSoFar); // no change. too soon.
+        }
+
+        // let a little more time and bytes pass.  still too soon for progress()
+        {
+            bytesSoFar += 1;
+            clockSim.advanceBoth(Duration.ofMillis(99));
+            assertEquals(4999, clockSim.getMonoMsecTime());
+
+            checkReachedEofAndException(bytesSoFar);
+            checkProgressNotCalled(bytesSoFar); // no change. too soon.
+        }
+
+        // check that having no time passing doesn't let events through.
+        {
+            bytesSoFar += 1;
+            checkProgressNotCalled(bytesSoFar); // no change. too soon.
+        }
+
+        // let time and bytes pass.  just barely enough to be long enough for next call.
+        {
+            bytesSoFar += 1;
+            clockSim.advanceBoth(Duration.ofMillis(1));
+            assertEquals(5000, clockSim.getMonoMsecTime());
+
+            checkReachedEofAndException(bytesSoFar);
+            checkProgressCalled(bytesSoFar);
+        }
+
+        // again, not enough to let progress through
+        {
+            bytesSoFar += 1;
+            clockSim.advanceBoth(Duration.ofMillis(999));
+            assertEquals(5999, clockSim.getMonoMsecTime());
+
+            checkReachedEofAndException(bytesSoFar);
+            checkProgressNotCalled(bytesSoFar);
+        }
+
+        // again, enough to let progress through & not exactly at threshold.
+        {
+            bytesSoFar += 1;
+            clockSim.advanceBoth(Duration.ofMillis(4002));
+            assertEquals(10001, clockSim.getMonoMsecTime());
+
+            checkReachedEofAndException(bytesSoFar);
+            checkProgressCalled(bytesSoFar);
+        }
+    }
+
+    // reachedEof & hitException are always passed along.
+    private void checkReachedEofAndException(long bytesSoFar) {
+        filtering.reachedEof(bytesSoFar);
+        verify(wrapped, times(1)).reachedEof(bytesSoFar);
+
+        filtering.hitException(exception, bytesSoFar);
+        verify(wrapped, times(1)).hitException(exception, bytesSoFar);
+    }
+
+    private void checkProgressCalled(long bytesSoFar) {
+        filtering.progress(bytesSoFar);
+        verify(wrapped, times(1)).progress(bytesSoFar);
+    }
+
+    private void checkProgressNotCalled(long bytesSoFar) {
+        filtering.progress(bytesSoFar);
+        verify(wrapped, never()).progress(bytesSoFar);
+    }
+}

--- a/core/src/test/java/com/backblaze/b2/client/B2LargeFileUploaderTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2LargeFileUploaderTest.java
@@ -18,6 +18,7 @@ import com.backblaze.b2.client.structures.B2Part;
 import com.backblaze.b2.client.structures.B2UploadFileRequest;
 import com.backblaze.b2.client.structures.B2UploadPartRequest;
 import com.backblaze.b2.client.structures.B2UploadPartUrlResponse;
+import com.backblaze.b2.util.B2Clock;
 import com.backblaze.b2.util.B2Collections;
 import org.junit.After;
 import org.junit.Rule;
@@ -350,7 +351,7 @@ public class B2LargeFileUploaderTest {
                 null,
                 B2Collections.mapOf(),
                 "upload",
-                System.currentTimeMillis());
+                B2Clock.get().getNowMsecTime());
 
 
         // arrange to answer get_upload_part_url (which will be called several times, but it's ok to reuse the same value since it's all mocked!)

--- a/core/src/test/java/com/backblaze/b2/client/B2SleeperTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2SleeperTest.java
@@ -4,6 +4,7 @@
  */
 package com.backblaze.b2.client;
 
+import com.backblaze.b2.util.B2Clock;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -19,9 +20,9 @@ public class B2SleeperTest {
 
     @Test
     public void testSleeping() {
-        final long beforeMsec = System.currentTimeMillis();
+        final long beforeMsec = B2Clock.get().getMonoMsecTime();
         sleeper.sleepSeconds(1);
-        final long afterMsec = System.currentTimeMillis();
+        final long afterMsec = B2Clock.get().getMonoMsecTime();
 
         // we should've slept most of a second! (and not thrown)
         assertTrue((afterMsec - beforeMsec) > 900);

--- a/core/src/test/java/com/backblaze/b2/client/B2SleeperTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2SleeperTest.java
@@ -5,6 +5,7 @@
 package com.backblaze.b2.client;
 
 import com.backblaze.b2.util.B2Clock;
+import com.backblaze.b2.util.B2ClockImpl;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -20,9 +21,10 @@ public class B2SleeperTest {
 
     @Test
     public void testSleeping() {
-        final long beforeMsec = B2Clock.get().getMonoMsecTime();
+        final B2Clock clock = new B2ClockImpl();
+        final long beforeMsec = clock.getMonoMsecTime();
         sleeper.sleepSeconds(1);
-        final long afterMsec = B2Clock.get().getMonoMsecTime();
+        final long afterMsec = clock.getMonoMsecTime();
 
         // we should've slept most of a second! (and not thrown)
         assertTrue((afterMsec - beforeMsec) > 900);

--- a/core/src/test/java/com/backblaze/b2/client/B2StorageClientImplTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2StorageClientImplTest.java
@@ -49,6 +49,7 @@ import com.backblaze.b2.client.structures.B2UploadPartRequest;
 import com.backblaze.b2.client.structures.B2UploadPartUrlResponse;
 import com.backblaze.b2.client.structures.B2UploadUrlResponse;
 import com.backblaze.b2.util.B2ByteRange;
+import com.backblaze.b2.util.B2Clock;
 import com.backblaze.b2.util.B2Collections;
 import com.backblaze.b2.util.B2ExecutorUtils;
 import com.backblaze.b2.util.B2Preconditions;
@@ -766,7 +767,7 @@ public class B2StorageClientImplTest {
                 null,
                 B2Collections.mapOf(),
                 "upload",
-                System.currentTimeMillis());
+                B2Clock.get().getNowMsecTime());
 
         final String largeFileId = largeFileVersion.getFileId();
 

--- a/core/src/test/java/com/backblaze/b2/client/B2TestHelpers.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2TestHelpers.java
@@ -13,6 +13,7 @@ import com.backblaze.b2.client.structures.B2LifecycleRule;
 import com.backblaze.b2.client.structures.B2Part;
 import com.backblaze.b2.client.structures.B2UploadPartUrlResponse;
 import com.backblaze.b2.client.structures.B2UploadUrlResponse;
+import com.backblaze.b2.util.B2Clock;
 import com.backblaze.b2.util.B2Collections;
 import com.backblaze.b2.util.B2Sha1;
 
@@ -84,7 +85,7 @@ public class B2TestHelpers {
                 SAMPLE_SHA1,
                 B2Collections.mapOf(),
                 "upload",
-                System.currentTimeMillis());
+                B2Clock.get().getNowMsecTime());
     }
 
     public static B2Part makePart(int i) {

--- a/core/src/test/java/com/backblaze/b2/util/B2ClockImplTest.java
+++ b/core/src/test/java/com/backblaze/b2/util/B2ClockImplTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017, Backblaze Inc. All Rights Reserved.
+ * License https://www.backblaze.com/using_b2_code.html
+ */
+package com.backblaze.b2.util;
+
+import org.junit.Test;
+
+import static com.backblaze.b2.util.B2DateTimeUtil.ONE_SECOND_IN_NANOS;
+import static org.junit.Assert.*;
+
+public class B2ClockImplTest {
+
+    @Test
+    public void test() throws InterruptedException {
+        final B2ClockImpl clock = new B2ClockImpl();
+
+        final long beforeNowMsecs = clock.getNowMsecTime();
+        final long beforeMonoMsecs = clock.getMonoMsecTime();
+        final long beforeNanos = clock.getMonoNanoTime();
+
+        Thread.sleep(1000);
+
+        final long afterNowMsecs = clock.getNowMsecTime();
+        final long afterMonoMsecs = clock.getMonoMsecTime();
+        final long afterNanos = clock.getMonoNanoTime();
+
+        final long deltaNowMsecs = afterNowMsecs - beforeNowMsecs;
+        final long deltaMonoMsecs = afterMonoMsecs - beforeMonoMsecs;
+        final long deltaNanos = afterNanos - beforeNanos;
+
+        assertTrue("nowMsecs: after(" + afterNowMsecs + ") - before(" + beforeNowMsecs + ") = " + deltaNowMsecs + " = " + (deltaNowMsecs / 1000.) + " (seconds)",
+                (deltaNowMsecs >= 1000) && (deltaNowMsecs <= 3000));
+
+        assertTrue("monoMsecs: after(" + afterMonoMsecs + ") - before(" + beforeMonoMsecs + ") = " + deltaMonoMsecs + " = " + (deltaMonoMsecs / 1000.) + " (seconds)",
+                (deltaMonoMsecs >= 1000) && (deltaMonoMsecs <= 3000));
+
+        assertTrue("nanos: after(" + afterNanos + ") - before(" + beforeNanos + ") = " + deltaNanos + " = " + (deltaNanos / 1000000000.) + " (seconds)",
+                (deltaNanos >= ONE_SECOND_IN_NANOS) && (deltaNanos <= 3L * ONE_SECOND_IN_NANOS));
+    }
+}

--- a/core/src/test/java/com/backblaze/b2/util/B2ClockImplTest.java
+++ b/core/src/test/java/com/backblaze/b2/util/B2ClockImplTest.java
@@ -7,7 +7,7 @@ package com.backblaze.b2.util;
 import org.junit.Test;
 
 import static com.backblaze.b2.util.B2DateTimeUtil.ONE_SECOND_IN_NANOS;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 public class B2ClockImplTest {
 
@@ -36,6 +36,6 @@ public class B2ClockImplTest {
                 (deltaMonoMsecs >= 1000) && (deltaMonoMsecs <= 3000));
 
         assertTrue("nanos: after(" + afterNanos + ") - before(" + beforeNanos + ") = " + deltaNanos + " = " + (deltaNanos / 1000000000.) + " (seconds)",
-                (deltaNanos >= ONE_SECOND_IN_NANOS) && (deltaNanos <= 3L * ONE_SECOND_IN_NANOS));
+                (deltaNanos >= ONE_SECOND_IN_NANOS) && (deltaNanos <= 3 * ONE_SECOND_IN_NANOS));
     }
 }

--- a/core/src/test/java/com/backblaze/b2/util/B2ClockSimTest.java
+++ b/core/src/test/java/com/backblaze/b2/util/B2ClockSimTest.java
@@ -22,7 +22,7 @@ public class B2ClockSimTest {
     @Test
     public void test() {
         // test create
-        final B2ClockSim clock = B2ClockSim.create(B2DateTimeUtil.EPOCH_TIME.plus(Duration.ofSeconds(6)));
+        final B2ClockSim clock = new B2ClockSim(B2DateTimeUtil.EPOCH_TIME.plus(Duration.ofSeconds(6)));
         assertEquals(6 * ONE_SECOND_IN_MSECS, clock.getNowMsecTime());
         assertEquals(0L, clock.getMonoNanoTime());
         assertEquals(0L, clock.getMonoMsecTime());
@@ -42,7 +42,7 @@ public class B2ClockSimTest {
 
     @Test
     public void testAdvanceWithNonPositiveDurations() {
-        final B2ClockSim clock = B2ClockSim.create(B2DateTimeUtil.EPOCH_TIME.plus(Duration.ofSeconds(6)));
+        final B2ClockSim clock = new B2ClockSim(B2DateTimeUtil.EPOCH_TIME.plus(Duration.ofSeconds(6)));
 
         // adding a zero duration should be fine.
         clock.advanceBoth(Duration.ZERO);

--- a/core/src/test/java/com/backblaze/b2/util/B2ClockSimTest.java
+++ b/core/src/test/java/com/backblaze/b2/util/B2ClockSimTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017, Backblaze Inc. All Rights Reserved.
+ * License https://www.backblaze.com/using_b2_code.html
+ */
+package com.backblaze.b2.util;
+
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.time.Duration;
+
+import static com.backblaze.b2.util.B2DateTimeUtil.ONE_SECOND_IN_MSECS;
+import static com.backblaze.b2.util.B2DateTimeUtil.ONE_SECOND_IN_NANOS;
+import static org.junit.Assert.assertEquals;
+
+public class B2ClockSimTest {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void test() {
+        // test create
+        final B2ClockSim clock = B2ClockSim.create(B2DateTimeUtil.EPOCH_TIME.plus(Duration.ofSeconds(6)));
+        assertEquals(6 * ONE_SECOND_IN_MSECS, clock.getNowMsecTime());
+        assertEquals(0L, clock.getMonoNanoTime());
+        assertEquals(0L, clock.getMonoMsecTime());
+
+        // test advanceBoth.  it should advance both types of time.
+        clock.advanceBoth(Duration.ofMinutes(1));
+        assertEquals((60 + 6) * ONE_SECOND_IN_MSECS, clock.getNowMsecTime());
+        assertEquals(60L * ONE_SECOND_IN_NANOS, clock.getMonoNanoTime());
+        assertEquals(60 * ONE_SECOND_IN_MSECS, clock.getMonoMsecTime());
+
+        // test advanceNow.  it should only advance the wall-clock time.
+        clock.advanceNow(Duration.ofHours(1));
+        assertEquals((3600 + 60 + 6) * ONE_SECOND_IN_MSECS, clock.getNowMsecTime());
+        assertEquals(60L * ONE_SECOND_IN_NANOS, clock.getMonoNanoTime());
+        assertEquals(60 * ONE_SECOND_IN_MSECS, clock.getMonoMsecTime());
+    }
+
+    @Test
+    public void testAdvanceWithNonPositiveDurations() {
+        final B2ClockSim clock = B2ClockSim.create(B2DateTimeUtil.EPOCH_TIME.plus(Duration.ofSeconds(6)));
+
+        // adding a zero duration should be fine.
+        clock.advanceBoth(Duration.ZERO);
+        clock.advanceNow(Duration.ZERO);
+
+        // advancing now by a negative time should be fine.
+        clock.advanceNow(Duration.ofSeconds(-1));
+        assertEquals(5 * ONE_SECOND_IN_MSECS, clock.getNowMsecTime());
+
+
+        // advancingBoth by a negative time should throw.
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("delta must be non-negative");
+        clock.advanceBoth(Duration.ofSeconds(-1));
+    }
+}

--- a/core/src/test/java/com/backblaze/b2/util/B2ClockSimTest.java
+++ b/core/src/test/java/com/backblaze/b2/util/B2ClockSimTest.java
@@ -30,13 +30,13 @@ public class B2ClockSimTest {
         // test advanceBoth.  it should advance both types of time.
         clock.advanceBoth(Duration.ofMinutes(1));
         assertEquals((60 + 6) * ONE_SECOND_IN_MSECS, clock.getNowMsecTime());
-        assertEquals(60L * ONE_SECOND_IN_NANOS, clock.getMonoNanoTime());
+        assertEquals(60 * ONE_SECOND_IN_NANOS, clock.getMonoNanoTime());
         assertEquals(60 * ONE_SECOND_IN_MSECS, clock.getMonoMsecTime());
 
         // test advanceNow.  it should only advance the wall-clock time.
         clock.advanceNow(Duration.ofHours(1));
         assertEquals((3600 + 60 + 6) * ONE_SECOND_IN_MSECS, clock.getNowMsecTime());
-        assertEquals(60L * ONE_SECOND_IN_NANOS, clock.getMonoNanoTime());
+        assertEquals(60 * ONE_SECOND_IN_NANOS, clock.getMonoNanoTime());
         assertEquals(60 * ONE_SECOND_IN_MSECS, clock.getMonoMsecTime());
     }
 

--- a/core/src/test/java/com/backblaze/b2/util/B2DateTimeUtilTest.java
+++ b/core/src/test/java/com/backblaze/b2/util/B2DateTimeUtilTest.java
@@ -117,6 +117,22 @@ public class B2DateTimeUtilTest {
     }
 
     @Test
+    public void testMillisecondsSinceEpoch() {
+        checkSinceEpochDateTime(0, "1970-01-01 00:00:00");
+        checkSinceEpochDateTime(B2DateTimeUtil.ONE_SECOND_IN_MSECS, "1970-01-01 00:00:01");
+        checkSinceEpochDateTime(B2DateTimeUtil.ONE_MINUTE_IN_MSECS, "1970-01-01 00:01:00");
+        checkSinceEpochDateTime(B2DateTimeUtil.ONE_HOUR_IN_MSECS, "1970-01-01 01:00:00");
+        checkSinceEpochDateTime(B2DateTimeUtil.ONE_DAY_IN_MSECS, "1970-01-02 00:00:00");
+        checkSinceEpochDateTime(31 * B2DateTimeUtil.ONE_DAY_IN_MSECS, "1970-02-01 00:00:00");
+    }
+
+    private void checkSinceEpochDateTime(long expectedMsecs, String dateTimeStr) {
+        LocalDateTime d = B2DateTimeUtil.parseDateTime(dateTimeStr);
+        assertEquals(expectedMsecs, B2DateTimeUtil.getMillisecondsSinceEpoch(d));
+    }
+
+
+    @Test
     public void test_forCoverage() {
         // grrrr....  i really don't want to have to do this.
         new B2DateTimeUtil();


### PR DESCRIPTION
there's a real implementation -- B2ClockImpl.
there's a simulator -- B2ClockSim.
there are tests.

i haven't yet exercised or tested B2Clock.set() and get().
i suspect there'll be some tweaks there to handle updating
the clock in unit tests, since it's a global and i don't
currently allow it to be set more than once.