### PR TITLE
Percent-encode files names when downloading by name.

### DIFF
--- a/core/src/main/java/com/backblaze/b2/client/B2StorageClientWebifierImpl.java
+++ b/core/src/main/java/com/backblaze/b2/client/B2StorageClientWebifierImpl.java
@@ -497,7 +497,7 @@ public class B2StorageClientWebifierImpl implements B2StorageClientWebifier {
         if (!url.endsWith("/")) {
             url += "/";
         }
-        url += "file/" + bucketName + "/" + fileName;
+        url += "file/" + bucketName + "/" + percentEncode(fileName);
         return url;
     }
 }

--- a/core/src/main/java/com/backblaze/b2/util/B2StringUtil.java
+++ b/core/src/main/java/com/backblaze/b2/util/B2StringUtil.java
@@ -36,7 +36,7 @@ public class B2StringUtil {
      */
     public static String percentEncode(String s) {
         try {
-            return URLEncoder.encode(s, UTF8);
+            return URLEncoder.encode(s, UTF8).replace("%2F", "/");
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException("UTF8 isn't supported? " + e.getMessage(), e);
         }

--- a/core/src/test/java/com/backblaze/b2/client/B2StorageClientWebifierImplTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2StorageClientWebifierImplTest.java
@@ -929,6 +929,25 @@ public class B2StorageClientWebifierImplTest {
     }
 
     @Test
+    public void testDownloadByNamePercentEncoded() throws B2Exception {
+        final B2DownloadByNameRequest request = B2DownloadByNameRequest
+                .builder(bucketName(1), "\u81ea\u7531")
+                .build();
+        webifier.downloadByName(ACCOUNT_AUTH, request, noopContentHandler);
+
+        webApiClient.check("getContent.\n" +
+                "url:\n" +
+                "    downloadUrl1/file/bucketName1/%E8%87%AA%E7%94%B1\n" +
+                "headers:\n" +
+                "    Authorization: accountToken1\n" +
+                "    User-Agent: SecretAgentMan/3.19.28\n" +
+                "    X-Bz-Test-Mode: force_cap_exceeded\n"
+        );
+
+        checkRequestCategory(OTHER, w -> w.downloadByName(ACCOUNT_AUTH, request, noopContentHandler));
+    }
+
+    @Test
     public void testDownloadByNameWithRange() throws B2Exception {
         final B2DownloadByNameRequest request = B2DownloadByNameRequest
                 .builder(bucketName(1), fileName(1))
@@ -1028,7 +1047,7 @@ public class B2StorageClientWebifierImplTest {
                 "    Content-Type: b2/x-auto\n" +
                 "    User-Agent: SecretAgentMan/3.19.28\n" +
                 "    X-Bz-Content-Sha1: 0a0a9f2a6772942557ab5355d76af442f8f65e01\n" +
-                "    X-Bz-File-Name: files%2F0001\n" +
+                "    X-Bz-File-Name: files/0001\n" +
                 "    X-Bz-Info-color: blue\n" +
                 "    X-Bz-Info-number: six\n" +
                 "    X-Bz-Info-src_last_modified_millis: 1234567\n" +
@@ -1078,7 +1097,7 @@ public class B2StorageClientWebifierImplTest {
                 "    Content-Type: b2/x-auto\n" +
                 "    User-Agent: SecretAgentMan/3.19.28\n" +
                 "    X-Bz-Content-Sha1: hex_digits_at_end\n" +
-                "    X-Bz-File-Name: files%2F0001\n" +
+                "    X-Bz-File-Name: files/0001\n" +
                 "    X-Bz-Info-color: blue\n" +
                 "    X-Bz-Info-number: six\n" +
                 "    X-Bz-Test-Mode: force_cap_exceeded\n" +

--- a/core/src/test/java/com/backblaze/b2/util/B2StringUtilTest.java
+++ b/core/src/test/java/com/backblaze/b2/util/B2StringUtilTest.java
@@ -34,7 +34,7 @@ public class B2StringUtilTest {
     @Test
     public void testPercentEncode() {
         assertEquals("", percentEncode(""));
-        assertEquals("a--%2F--b--%2B--%3A--%7C", percentEncode("a--/--b--+--:--|"));
+        assertEquals("a--/--b--%2B--%3A--%7C--+--", percentEncode("a--/--b--+--:--|-- --"));
     }
 
     @Test


### PR DESCRIPTION
Also, update the percent-encoding to match the sample code
from the B2 web site.  It's not necessary to encode "/", and
file names read better when it's not encoded.

Testing:
- unit tests