### PR TITLE
b2StorageClient: add getUploadUrl() and getUploadPartUrl()

### DIFF
--- a/core/src/main/java/com/backblaze/b2/client/B2StorageClient.java
+++ b/core/src/main/java/com/backblaze/b2/client/B2StorageClient.java
@@ -19,6 +19,8 @@ import com.backblaze.b2.client.structures.B2DownloadByNameRequest;
 import com.backblaze.b2.client.structures.B2FileVersion;
 import com.backblaze.b2.client.structures.B2GetDownloadAuthorizationRequest;
 import com.backblaze.b2.client.structures.B2GetFileInfoRequest;
+import com.backblaze.b2.client.structures.B2GetUploadPartUrlRequest;
+import com.backblaze.b2.client.structures.B2GetUploadUrlRequest;
 import com.backblaze.b2.client.structures.B2HideFileRequest;
 import com.backblaze.b2.client.structures.B2ListBucketsRequest;
 import com.backblaze.b2.client.structures.B2ListBucketsResponse;
@@ -28,6 +30,8 @@ import com.backblaze.b2.client.structures.B2ListPartsRequest;
 import com.backblaze.b2.client.structures.B2ListUnfinishedLargeFilesRequest;
 import com.backblaze.b2.client.structures.B2UpdateBucketRequest;
 import com.backblaze.b2.client.structures.B2UploadFileRequest;
+import com.backblaze.b2.client.structures.B2UploadPartUrlResponse;
+import com.backblaze.b2.client.structures.B2UploadUrlResponse;
 
 import java.io.Closeable;
 import java.util.List;
@@ -574,6 +578,52 @@ public interface B2StorageClient extends Closeable {
      */
     void invalidateAccountAuthorization();
 
+
+    /**
+     * This method allows the caller to get an upload url and authorization
+     * token directly.
+     *
+     * Note that the SDK has lots of logic to upload files and getting upload URLs
+     * and using them outside the SDK means that you need to handle lots of details
+     * of uploading by yourself including:
+     *   * retrying based on the types of errors you get, with proper backoff.
+     *   * refreshing your account authorization when it expires.
+     *   * reusing upload urls when possible
+     *   * etc.
+     *
+     * When possible you should seriously consider using uploadSmallFile() and
+     * uploadLargeFile() instead of reimplementing that logic.  If there's a
+     * reason you can't use those methods, let us know.  Perhaps we can improve
+     * things together to meet your needs.
+     *
+     * @param request specifies details about the desired upload url and credentials.
+     * @return the response from the server.
+     * @throws B2Exception if there's any trouble.
+     */
+    B2UploadUrlResponse getUploadUrl(B2GetUploadUrlRequest request) throws B2Exception;
+
+    /**
+     * This method allows the caller to get an upload url and authorization
+     * token directly for uploading a large file part.
+     *
+     * Note that the SDK has lots of logic to upload files and getting upload URLs
+     * and using them outside the SDK means that you need to handle lots of details
+     * of uploading by yourself including:
+     *   * retrying based on the types of errors you get, with proper backoff.
+     *   * refreshing your account authorization when it expires.
+     *   * reusing upload urls when possible
+     *   * etc.
+     *
+     * When possible you should seriously consider using uploadSmallFile() and
+     * uploadLargeFile() instead of reimplementing that logic.  If there's a
+     * reason you can't use those methods, let us know.  Perhaps we can improve
+     * things together to meet your needs.
+
+     * @param request specifies details about the desired upload url and credentials.
+     * @return the response from the server.
+     * @throws B2Exception if there's any trouble.
+     */
+    B2UploadPartUrlResponse getUploadPartUrl(B2GetUploadPartUrlRequest request) throws B2Exception;
 
     /**
      * Closes this instance, releasing resources.

--- a/core/src/main/java/com/backblaze/b2/client/B2StorageClientImpl.java
+++ b/core/src/main/java/com/backblaze/b2/client/B2StorageClientImpl.java
@@ -22,6 +22,8 @@ import com.backblaze.b2.client.structures.B2DownloadByNameRequest;
 import com.backblaze.b2.client.structures.B2FileVersion;
 import com.backblaze.b2.client.structures.B2GetDownloadAuthorizationRequest;
 import com.backblaze.b2.client.structures.B2GetFileInfoRequest;
+import com.backblaze.b2.client.structures.B2GetUploadPartUrlRequest;
+import com.backblaze.b2.client.structures.B2GetUploadUrlRequest;
 import com.backblaze.b2.client.structures.B2HideFileRequest;
 import com.backblaze.b2.client.structures.B2ListBucketsRequest;
 import com.backblaze.b2.client.structures.B2ListBucketsResponse;
@@ -36,6 +38,7 @@ import com.backblaze.b2.client.structures.B2ListUnfinishedLargeFilesResponse;
 import com.backblaze.b2.client.structures.B2Part;
 import com.backblaze.b2.client.structures.B2UpdateBucketRequest;
 import com.backblaze.b2.client.structures.B2UploadFileRequest;
+import com.backblaze.b2.client.structures.B2UploadPartUrlResponse;
 import com.backblaze.b2.client.structures.B2UploadUrlResponse;
 
 import java.io.IOException;
@@ -339,6 +342,23 @@ public class B2StorageClientImpl implements B2StorageClient {
     @Override
     public void invalidateAccountAuthorization() {
         accountAuthCache.clear();
+    }
+
+
+    @Override
+    public B2UploadUrlResponse getUploadUrl(B2GetUploadUrlRequest request) throws B2Exception {
+        return retryer.doRetry("b2_get_upload_url",
+                accountAuthCache,
+                () -> webifier.getUploadUrl(accountAuthCache.get(), request),
+                retryPolicySupplier.get());
+    }
+
+    @Override
+    public B2UploadPartUrlResponse getUploadPartUrl(B2GetUploadPartUrlRequest request) throws B2Exception {
+        return retryer.doRetry("b2_get_upload_part_url",
+                accountAuthCache,
+                () -> webifier.getUploadPartUrl(accountAuthCache.get(), request),
+                retryPolicySupplier.get());
     }
 
     //

--- a/core/src/main/java/com/backblaze/b2/client/B2UploadPartUrlCache.java
+++ b/core/src/main/java/com/backblaze/b2/client/B2UploadPartUrlCache.java
@@ -64,7 +64,7 @@ class B2UploadPartUrlCache {
         }
 
         // we don't have an answer yet, so ask the server for one and return it.
-        final B2GetUploadPartUrlRequest request = new B2GetUploadPartUrlRequest(largeFileId);
+        final B2GetUploadPartUrlRequest request = B2GetUploadPartUrlRequest.builder(largeFileId).build();
         return webifier.getUploadPartUrl(accountAuthCache.get(), request);
     }
 

--- a/core/src/main/java/com/backblaze/b2/client/B2UploadUrlCache.java
+++ b/core/src/main/java/com/backblaze/b2/client/B2UploadUrlCache.java
@@ -83,7 +83,7 @@ class B2UploadUrlCache {
         }
 
         // we don't have an answer yet, so ask the server for one and return it.
-        final B2GetUploadUrlRequest request = new B2GetUploadUrlRequest(bucketId);
+        final B2GetUploadUrlRequest request = B2GetUploadUrlRequest.builder(bucketId).build();
         return webifier.getUploadUrl(accountAuthCache.get(), request);
     }
 

--- a/core/src/main/java/com/backblaze/b2/client/structures/B2GetUploadPartUrlRequest.java
+++ b/core/src/main/java/com/backblaze/b2/client/structures/B2GetUploadPartUrlRequest.java
@@ -13,7 +13,7 @@ public class B2GetUploadPartUrlRequest {
     private final String fileId;
 
     @B2Json.constructor(params = "fileId")
-    public B2GetUploadPartUrlRequest(String fileId) {
+    private B2GetUploadPartUrlRequest(String fileId) {
         this.fileId = fileId;
     }
 
@@ -33,4 +33,21 @@ public class B2GetUploadPartUrlRequest {
     public int hashCode() {
         return Objects.hash(getFileId());
     }
+
+    public static Builder builder(String bucketId) {
+        return new Builder(bucketId);
+    }
+
+    public static class Builder {
+        private final String fileId;
+
+        public Builder(String fileId) {
+            this.fileId = fileId;
+        }
+
+        public B2GetUploadPartUrlRequest build() {
+            return new B2GetUploadPartUrlRequest(fileId);
+        }
+    }
+
 }

--- a/core/src/main/java/com/backblaze/b2/client/structures/B2GetUploadUrlRequest.java
+++ b/core/src/main/java/com/backblaze/b2/client/structures/B2GetUploadUrlRequest.java
@@ -13,7 +13,7 @@ public class B2GetUploadUrlRequest {
     private final String bucketId;
 
     @B2Json.constructor(params = "bucketId")
-    public B2GetUploadUrlRequest(String bucketId) {
+    private B2GetUploadUrlRequest(String bucketId) {
         this.bucketId = bucketId;
     }
 
@@ -32,5 +32,21 @@ public class B2GetUploadUrlRequest {
     @Override
     public int hashCode() {
         return Objects.hash(getBucketId());
+    }
+
+    public static Builder builder(String bucketId) {
+        return new Builder(bucketId);
+    }
+
+    public static class Builder {
+        private final String bucketId;
+
+        public Builder(String bucketId) {
+            this.bucketId = bucketId;
+        }
+
+        public B2GetUploadUrlRequest build() {
+            return new B2GetUploadUrlRequest(bucketId);
+        }
     }
 }

--- a/core/src/test/java/com/backblaze/b2/client/B2LargeFileUploaderTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2LargeFileUploaderTest.java
@@ -182,7 +182,7 @@ public class B2LargeFileUploaderTest {
         when(webifier.startLargeFile(anyObject(), anyObject())).thenReturn(largeFileVersion);
 
         // arrange to answer get_upload_part_url (which will be called several times, but it's ok to reuse the same value since it's all mocked!)
-        final B2GetUploadPartUrlRequest partUrlRequest = new B2GetUploadPartUrlRequest(largeFileVersion.getFileId());
+        final B2GetUploadPartUrlRequest partUrlRequest = B2GetUploadPartUrlRequest.builder(largeFileVersion.getFileId()).build();
         final B2UploadPartUrlResponse partUrl = new B2UploadPartUrlResponse(largeFileVersion.getFileId(), "uploadPartUrl", "uploadPartAuthToken");
         when(webifier.getUploadPartUrl(anyObject(), eq(partUrlRequest))).thenReturn(partUrl);
 
@@ -542,7 +542,7 @@ public class B2LargeFileUploaderTest {
 
 
         // arrange to answer get_upload_part_url (which will be called several times, but it's ok to reuse the same value since it's all mocked!)
-        final B2GetUploadPartUrlRequest partUrlRequest = new B2GetUploadPartUrlRequest(largeFileId);
+        final B2GetUploadPartUrlRequest partUrlRequest = B2GetUploadPartUrlRequest.builder(largeFileId).build();
         final B2UploadPartUrlResponse partUrl = new B2UploadPartUrlResponse(largeFileId, "uploadPartUrl", "uploadPartAuthToken");
         when(webifier.getUploadPartUrl(anyObject(), eq(partUrlRequest))).thenReturn(partUrl);
 

--- a/core/src/test/java/com/backblaze/b2/client/B2StorageClientImplTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2StorageClientImplTest.java
@@ -84,6 +84,7 @@ import static com.backblaze.b2.util.B2Collections.listOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -738,7 +739,7 @@ public class B2StorageClientImplTest {
     @Test
     public void testSmallFileUpload() throws B2Exception, IOException {
         // arrange for an uploadUrl
-        final B2GetUploadUrlRequest uploadUrlRequest = new B2GetUploadUrlRequest(bucketId(1));
+        final B2GetUploadUrlRequest uploadUrlRequest = B2GetUploadUrlRequest.builder(bucketId(1)).build();
         final B2UploadUrlResponse uploadUrl = new B2UploadUrlResponse(bucketId(1), "uploadUrl", "uploadAuthToken");
         when(webifier.getUploadUrl(anyObject(), eq(uploadUrlRequest))).thenReturn(uploadUrl);
 
@@ -790,7 +791,7 @@ public class B2StorageClientImplTest {
         when(webifier.startLargeFile(anyObject(), eq(startLargeRequest))).thenReturn(largeFileVersion);
 
         // arrange to answer get_upload_part_url (which will be called several times, but it's ok to reuse the same value since it's all mocked!)
-        final B2GetUploadPartUrlRequest partUrlRequest = new B2GetUploadPartUrlRequest(largeFileVersion.getFileId());
+        final B2GetUploadPartUrlRequest partUrlRequest = B2GetUploadPartUrlRequest.builder(largeFileVersion.getFileId()).build();
         final B2UploadPartUrlResponse partUrl = new B2UploadPartUrlResponse(largeFileVersion.getFileId(), "uploadPartUrl", "uploadPartAuthToken");
         when(webifier.getUploadPartUrl(anyObject(), eq(partUrlRequest))).thenReturn(partUrl);
 
@@ -876,7 +877,7 @@ public class B2StorageClientImplTest {
         when(webifier.listParts(anyObject(), anyObject())).thenReturn(listPartsResponse);
 
         // arrange to answer get_upload_part_url (which will be called several times, but it's ok to reuse the same value since it's all mocked!)
-        final B2GetUploadPartUrlRequest partUrlRequest = new B2GetUploadPartUrlRequest(largeFileId);
+        final B2GetUploadPartUrlRequest partUrlRequest = B2GetUploadPartUrlRequest.builder(largeFileId).build();
         final B2UploadPartUrlResponse partUrl = new B2UploadPartUrlResponse(largeFileId, "uploadPartUrl", "uploadPartAuthToken");
         when(webifier.getUploadPartUrl(anyObject(), eq(partUrlRequest))).thenReturn(partUrl);
 
@@ -901,6 +902,30 @@ public class B2StorageClientImplTest {
         verify(webifier, times(1)).getUploadPartUrl(anyObject(), anyObject());
         verify(webifier, times(1)).uploadPart(anyObject(), anyObject());
         verify(webifier, times(1)).finishLargeFile(anyObject(), anyObject());
+    }
+
+    @Test
+    public void testGetUploadUrl() throws B2Exception {
+        final B2GetUploadUrlRequest request = B2GetUploadUrlRequest.builder(bucketId(1)).build();
+        final B2UploadUrlResponse response = new B2UploadUrlResponse(bucketId(1), "uploadUrl", "uploadAuthToken");
+        when(webifier.getUploadUrl(anyObject(), eq(request))).thenReturn(response);
+
+        assertTrue(response == client.getUploadUrl(request));
+
+        verify(webifier, times(1)).authorizeAccount(anyObject());
+        verify(webifier, times(1)).getUploadUrl(anyObject(), anyObject());
+    }
+
+    @Test
+    public void testGetUploadPartUrl() throws B2Exception {
+        final B2GetUploadPartUrlRequest request = B2GetUploadPartUrlRequest.builder(bucketId(1)).build();
+        final B2UploadPartUrlResponse response = new B2UploadPartUrlResponse(bucketId(1), "uploadUrl", "uploadAuthToken");
+        when(webifier.getUploadPartUrl(anyObject(), eq(request))).thenReturn(response);
+
+        assertTrue(response == client.getUploadPartUrl(request));
+
+        verify(webifier, times(1)).authorizeAccount(anyObject());
+        verify(webifier, times(1)).getUploadPartUrl(anyObject(), anyObject());
     }
 
     @Test

--- a/core/src/test/java/com/backblaze/b2/client/B2StorageClientWebifierImplTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2StorageClientWebifierImplTest.java
@@ -15,7 +15,6 @@ import com.backblaze.b2.client.structures.B2AccountAuthorization;
 import com.backblaze.b2.client.structures.B2AuthorizeAccountRequest;
 import com.backblaze.b2.client.structures.B2BucketTypes;
 import com.backblaze.b2.client.structures.B2CancelLargeFileRequest;
-import com.backblaze.b2.client.structures.B2CorsRule;
 import com.backblaze.b2.client.structures.B2CreateBucketRequest;
 import com.backblaze.b2.client.structures.B2CreateBucketRequestReal;
 import com.backblaze.b2.client.structures.B2DeleteBucketRequestReal;
@@ -446,7 +445,7 @@ public class B2StorageClientWebifierImplTest {
 
     @Test
     public void testGetUploadUrl() throws B2Exception {
-        final B2GetUploadUrlRequest request = new B2GetUploadUrlRequest(bucketId(1));
+        final B2GetUploadUrlRequest request = B2GetUploadUrlRequest.builder(bucketId(1)).build();
         webifier.getUploadUrl(ACCOUNT_AUTH, request);
 
         webApiClient.check("postJsonReturnJson.\n" +
@@ -469,7 +468,7 @@ public class B2StorageClientWebifierImplTest {
 
     @Test
     public void testGetUploadPartUrl() throws B2Exception {
-        final B2GetUploadPartUrlRequest request = new B2GetUploadPartUrlRequest(fileId(1));
+        final B2GetUploadPartUrlRequest request = B2GetUploadPartUrlRequest.builder(fileId(1)).build();
         webifier.getUploadPartUrl(ACCOUNT_AUTH, request);
 
         webApiClient.check("postJsonReturnJson.\n" +


### PR DESCRIPTION
using these directly is mostly discouraged because the SDK
handles lots of authentication and retry logic for you in
uploadSmallFile() and uploadLargeFile() and it won't do
that if you just get these upload urls directly and use
them outside its logic.

that said, they could be useful if you needed to give an
upload URL and authToken to some code that can't use the SDK.