### PR TITLE
tests/clocks: make sure the unit tests all use a simulated clock.

### DIFF
--- a/core/src/test/java/com/backblaze/b2/client/B2AccountAuthorizationCacheTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2AccountAuthorizationCacheTest.java
@@ -7,6 +7,7 @@ package com.backblaze.b2.client;
 import com.backblaze.b2.client.exceptions.B2Exception;
 import com.backblaze.b2.client.exceptions.B2InternalErrorException;
 import com.backblaze.b2.client.structures.B2AccountAuthorization;
+import com.backblaze.b2.util.B2BaseTest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -21,7 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-public class B2AccountAuthorizationCacheTest {
+public class B2AccountAuthorizationCacheTest extends B2BaseTest {
     private final B2StorageClientWebifier webifier = mock(B2StorageClientWebifier.class);
     private final B2AccountAuthorizer authorizer = mock(B2AccountAuthorizer.class);
 

--- a/core/src/test/java/com/backblaze/b2/client/B2BoundedLruMapTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2BoundedLruMapTest.java
@@ -4,12 +4,13 @@
  */
 package com.backblaze.b2.client;
 
+import com.backblaze.b2.util.B2BaseTest;
 import org.junit.Test;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
-public class B2BoundedLruMapTest {
+public class B2BoundedLruMapTest extends B2BaseTest {
     @Test
     public void testOrderingAndMax() {
         final B2BoundedLruMap<String,Integer> map = B2BoundedLruMap.withMax(3);

--- a/core/src/test/java/com/backblaze/b2/client/B2ByteProgressFilteringListenerTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2ByteProgressFilteringListenerTest.java
@@ -2,6 +2,7 @@ package com.backblaze.b2.client;/*
  * Copyright 2017, Backblaze, Inc. All rights reserved. 
  */
 
+import com.backblaze.b2.util.B2BaseTest;
 import com.backblaze.b2.util.B2ByteProgressListener;
 import com.backblaze.b2.util.B2Clock;
 import com.backblaze.b2.util.B2ClockSim;
@@ -18,7 +19,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-public class B2ByteProgressFilteringListenerTest {
+public class B2ByteProgressFilteringListenerTest extends B2BaseTest {
     private final B2ClockSim clockSim = B2Clock.useSimulator(parseDateTime("2017-08-31 00:00:00"));
     private final B2ByteProgressListener wrapped = mock(B2ByteProgressListener.class);
     private final B2ByteProgressListener filtering = new B2ByteProgressFilteringListener(wrapped);

--- a/core/src/test/java/com/backblaze/b2/client/B2ClientConfigTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2ClientConfigTest.java
@@ -7,6 +7,7 @@ package com.backblaze.b2.client;
 import com.backblaze.b2.client.exceptions.B2Exception;
 import com.backblaze.b2.client.structures.B2AccountAuthorization;
 import com.backblaze.b2.client.structures.B2AuthorizeAccountRequest;
+import com.backblaze.b2.util.B2BaseTest;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -18,7 +19,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-public class B2ClientConfigTest {
+public class B2ClientConfigTest extends B2BaseTest {
     private static final String USER_AGENT = "B2ClientConfigTest/0.0.1";
     private final B2AccountAuthorizer AUTHORIZER = new B2AccountAuthorizer() {
         @Override

--- a/core/src/test/java/com/backblaze/b2/client/B2ContentDetailsForUploadTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2ContentDetailsForUploadTest.java
@@ -9,6 +9,7 @@ import com.backblaze.b2.client.contentSources.B2ContentSource;
 import com.backblaze.b2.client.contentSources.B2Headers;
 import com.backblaze.b2.client.exceptions.B2Exception;
 import com.backblaze.b2.client.exceptions.B2LocalException;
+import com.backblaze.b2.util.B2BaseTest;
 import com.backblaze.b2.util.B2IoUtils;
 import com.backblaze.b2.util.B2StringUtil;
 import org.junit.Rule;
@@ -22,7 +23,7 @@ import java.io.InputStream;
 
 import static junit.framework.TestCase.assertEquals;
 
-public class B2ContentDetailsForUploadTest {
+public class B2ContentDetailsForUploadTest extends B2BaseTest {
     private static final String CONTENTS = "Hello, World!";
     private static final byte[] CONTENTS_BYTES = B2StringUtil.getUtf8Bytes(CONTENTS);
     private static final String SHA1 = "0a0a9f2a6772942557ab5355d76af442f8f65e01";

--- a/core/src/test/java/com/backblaze/b2/client/B2ContentSourceWithByteProgressListenerTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2ContentSourceWithByteProgressListenerTest.java
@@ -3,6 +3,7 @@ package com.backblaze.b2.client;/*
  */
 
 import com.backblaze.b2.client.contentSources.B2ContentSource;
+import com.backblaze.b2.util.B2BaseTest;
 import com.backblaze.b2.util.B2ByteProgressListener;
 import com.backblaze.b2.util.B2InputStreamWithByteProgressListener;
 import org.junit.After;
@@ -18,7 +19,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-public class B2ContentSourceWithByteProgressListenerTest {
+public class B2ContentSourceWithByteProgressListenerTest extends B2BaseTest {
     private static final int EOF = -1;
 
     private final B2ContentSource wrappedSource = mock(B2ContentSource.class);

--- a/core/src/test/java/com/backblaze/b2/client/B2DefaultRetryPolicyTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2DefaultRetryPolicyTest.java
@@ -7,13 +7,14 @@ package com.backblaze.b2.client;
 import com.backblaze.b2.client.exceptions.B2Exception;
 import com.backblaze.b2.client.exceptions.B2InternalErrorException;
 import com.backblaze.b2.client.exceptions.B2UnauthorizedException;
+import com.backblaze.b2.util.B2BaseTest;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-public class B2DefaultRetryPolicyTest {
+public class B2DefaultRetryPolicyTest extends B2BaseTest {
     private static final String OP = "operation";
     private final B2RetryPolicy policy = new B2DefaultRetryPolicy();
 

--- a/core/src/test/java/com/backblaze/b2/client/B2LargeFileUploaderTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2LargeFileUploaderTest.java
@@ -21,6 +21,7 @@ import com.backblaze.b2.client.structures.B2UploadPartRequest;
 import com.backblaze.b2.client.structures.B2UploadPartUrlResponse;
 import com.backblaze.b2.client.structures.B2UploadProgress;
 import com.backblaze.b2.client.structures.B2UploadState;
+import com.backblaze.b2.util.B2BaseTest;
 import com.backblaze.b2.util.B2Clock;
 import com.backblaze.b2.util.B2Collections;
 import org.junit.After;
@@ -71,7 +72,7 @@ import static org.mockito.Mockito.when;
  * The normal, easy successful use of B2LargeFileUploader is covered in B2StorageClientImplTest.
  * This test class covers exception paths.
  */
-public class B2LargeFileUploaderTest {
+public class B2LargeFileUploaderTest extends B2BaseTest {
     private final B2Sleeper sleeper = mock(B2Sleeper.class);
     private final B2Retryer retryer = new B2Retryer(sleeper);
     private final B2StorageClientWebifier webifier = mock(B2StorageClientWebifier.class);

--- a/core/src/test/java/com/backblaze/b2/client/B2ListFileNamesIterableTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2ListFileNamesIterableTest.java
@@ -10,6 +10,7 @@ import com.backblaze.b2.client.exceptions.B2RuntimeException;
 import com.backblaze.b2.client.structures.B2FileVersion;
 import com.backblaze.b2.client.structures.B2ListFileNamesRequest;
 import com.backblaze.b2.client.structures.B2ListFileNamesResponse;
+import com.backblaze.b2.util.B2BaseTest;
 import com.backblaze.b2.util.B2Collections;
 import org.junit.Rule;
 import org.junit.Test;
@@ -28,7 +29,7 @@ import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class B2ListFileNamesIterableTest {
+public class B2ListFileNamesIterableTest extends B2BaseTest {
     private final String BUCKET_ID = bucketId(1);
     private final B2StorageClientImpl client = mock(B2StorageClientImpl.class);
 

--- a/core/src/test/java/com/backblaze/b2/client/B2ListFileVersionsIterableTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2ListFileVersionsIterableTest.java
@@ -8,6 +8,7 @@ import com.backblaze.b2.client.exceptions.B2Exception;
 import com.backblaze.b2.client.structures.B2FileVersion;
 import com.backblaze.b2.client.structures.B2ListFileVersionsRequest;
 import com.backblaze.b2.client.structures.B2ListFileVersionsResponse;
+import com.backblaze.b2.util.B2BaseTest;
 import com.backblaze.b2.util.B2Collections;
 import org.junit.Test;
 
@@ -24,7 +25,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class B2ListFileVersionsIterableTest {
+public class B2ListFileVersionsIterableTest extends B2BaseTest {
     private final String BUCKET_ID = bucketId(1);
     private final B2StorageClientImpl client = mock(B2StorageClientImpl.class);
 

--- a/core/src/test/java/com/backblaze/b2/client/B2ListPartsIterableImplTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2ListPartsIterableImplTest.java
@@ -10,6 +10,7 @@ import com.backblaze.b2.client.exceptions.B2RuntimeException;
 import com.backblaze.b2.client.structures.B2ListPartsRequest;
 import com.backblaze.b2.client.structures.B2ListPartsResponse;
 import com.backblaze.b2.client.structures.B2Part;
+import com.backblaze.b2.util.B2BaseTest;
 import com.backblaze.b2.util.B2Collections;
 import org.junit.Rule;
 import org.junit.Test;
@@ -25,7 +26,7 @@ import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class B2ListPartsIterableImplTest {
+public class B2ListPartsIterableImplTest extends B2BaseTest {
     private final String LARGE_FILE_ID = fileId(1);
     private final B2StorageClientImpl client = mock(B2StorageClientImpl.class);
 

--- a/core/src/test/java/com/backblaze/b2/client/B2ListUnfinishedLargeFilesIterableTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2ListUnfinishedLargeFilesIterableTest.java
@@ -8,6 +8,7 @@ import com.backblaze.b2.client.exceptions.B2Exception;
 import com.backblaze.b2.client.structures.B2FileVersion;
 import com.backblaze.b2.client.structures.B2ListUnfinishedLargeFilesRequest;
 import com.backblaze.b2.client.structures.B2ListUnfinishedLargeFilesResponse;
+import com.backblaze.b2.util.B2BaseTest;
 import com.backblaze.b2.util.B2Collections;
 import org.junit.Rule;
 import org.junit.Test;
@@ -24,7 +25,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class B2ListUnfinishedLargeFilesIterableTest {
+public class B2ListUnfinishedLargeFilesIterableTest extends B2BaseTest {
     private final String BUCKET_ID = bucketId(1);
     private final B2StorageClientImpl client = mock(B2StorageClientImpl.class);
 

--- a/core/src/test/java/com/backblaze/b2/client/B2PartOfContentSourceTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2PartOfContentSourceTest.java
@@ -5,6 +5,7 @@
 package com.backblaze.b2.client;
 
 import com.backblaze.b2.client.contentSources.B2ContentSource;
+import com.backblaze.b2.util.B2BaseTest;
 import com.backblaze.b2.util.B2InputStreamExcerpt;
 import org.junit.Rule;
 import org.junit.Test;
@@ -21,7 +22,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class B2PartOfContentSourceTest {
+public class B2PartOfContentSourceTest extends B2BaseTest {
     final B2ContentSource source = mock(B2ContentSource.class);
     final B2PartOfContentSource partOf = new B2PartOfContentSource(source, 26, 100);
 

--- a/core/src/test/java/com/backblaze/b2/client/B2PartSizesTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2PartSizesTest.java
@@ -5,6 +5,7 @@
 package com.backblaze.b2.client;
 
 import com.backblaze.b2.client.structures.B2AccountAuthorization;
+import com.backblaze.b2.util.B2BaseTest;
 import com.backblaze.b2.util.B2Collections;
 import org.junit.Rule;
 import org.junit.Test;
@@ -15,7 +16,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class B2PartSizesTest {
+public class B2PartSizesTest extends B2BaseTest {
     private final long GB = 1000 * 1000 * 1000;
     private final B2AccountAuthorization accountAuth = B2TestHelpers.makeAuth(1);
     private final B2PartSizes partSizes = B2PartSizes.from(accountAuth);

--- a/core/src/test/java/com/backblaze/b2/client/B2PartSpecTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2PartSpecTest.java
@@ -4,13 +4,14 @@
  */
 package com.backblaze.b2.client;
 
+import com.backblaze.b2.util.B2BaseTest;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-public class B2PartSpecTest {
+public class B2PartSpecTest extends B2BaseTest {
     @Test
     public void test() {
         final B2PartSpec a = new B2PartSpec(1, 0, 100);

--- a/core/src/test/java/com/backblaze/b2/client/B2RetryerTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2RetryerTest.java
@@ -16,6 +16,7 @@ import com.backblaze.b2.client.exceptions.B2ServiceUnavailableException;
 import com.backblaze.b2.client.exceptions.B2TooManyRequestsException;
 import com.backblaze.b2.client.exceptions.B2UnauthorizedException;
 import com.backblaze.b2.client.exceptions.B2UnauthorizedException.RequestCategory;
+import com.backblaze.b2.util.B2BaseTest;
 import com.backblaze.b2.util.B2Preconditions;
 import org.junit.Test;
 
@@ -37,7 +38,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-public class B2RetryerTest {
+public class B2RetryerTest extends B2BaseTest {
     private static final String OP = "operation";
 
     // we need to mock this so we don't really sleep.

--- a/core/src/test/java/com/backblaze/b2/client/B2SdkTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2SdkTest.java
@@ -4,6 +4,7 @@
  */
 package com.backblaze.b2.client;
 
+import com.backblaze.b2.util.B2BaseTest;
 import org.junit.Test;
 
 import java.util.regex.Pattern;
@@ -11,7 +12,7 @@ import java.util.regex.Pattern;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class B2SdkTest {
+public class B2SdkTest extends B2BaseTest {
     // our versions are three integers separated by periods, with an
     // optional "-prereleaseName" at the end.  see semver.org
     private static final Pattern VERSION_PATTERN = Pattern.compile("^\\d+[.]\\d+[.]\\d+(-[a-zA-Z0-9]+)?$");

--- a/core/src/test/java/com/backblaze/b2/client/B2SleeperTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2SleeperTest.java
@@ -4,6 +4,7 @@
  */
 package com.backblaze.b2.client;
 
+import com.backblaze.b2.util.B2BaseTest;
 import com.backblaze.b2.util.B2Clock;
 import com.backblaze.b2.util.B2ClockImpl;
 import org.junit.Rule;
@@ -12,7 +13,7 @@ import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.assertTrue;
 
-public class B2SleeperTest {
+public class B2SleeperTest extends B2BaseTest {
     private final B2Sleeper sleeper = new B2Sleeper();
 
     @Rule

--- a/core/src/test/java/com/backblaze/b2/client/B2StorageClientImplTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2StorageClientImplTest.java
@@ -50,6 +50,7 @@ import com.backblaze.b2.client.structures.B2UploadPartRequest;
 import com.backblaze.b2.client.structures.B2UploadPartUrlResponse;
 import com.backblaze.b2.client.structures.B2UploadProgress;
 import com.backblaze.b2.client.structures.B2UploadUrlResponse;
+import com.backblaze.b2.util.B2BaseTest;
 import com.backblaze.b2.util.B2ByteRange;
 import com.backblaze.b2.util.B2Clock;
 import com.backblaze.b2.util.B2Collections;
@@ -97,7 +98,7 @@ import static org.mockito.Mockito.when;
 /**
  */
 @SuppressWarnings("unchecked")
-public class B2StorageClientImplTest {
+public class B2StorageClientImplTest extends B2BaseTest {
     private static final B2AccountAuthorization ACCOUNT_AUTH = B2TestHelpers.makeAuth(1);
     private static final String ACCOUNT_ID = ACCOUNT_AUTH.getAccountId();
     private static final String APPLICATION_KEY = "applicationKey";

--- a/core/src/test/java/com/backblaze/b2/client/B2StorageClientWebifierImplTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2StorageClientWebifierImplTest.java
@@ -43,6 +43,7 @@ import com.backblaze.b2.client.structures.B2UploadProgress;
 import com.backblaze.b2.client.structures.B2UploadState;
 import com.backblaze.b2.client.structures.B2UploadUrlResponse;
 import com.backblaze.b2.client.webApiClients.B2WebApiClient;
+import com.backblaze.b2.util.B2BaseTest;
 import com.backblaze.b2.util.B2ByteRange;
 import com.backblaze.b2.util.B2Collections;
 import com.backblaze.b2.util.B2IoUtils;
@@ -83,7 +84,7 @@ import static org.mockito.Mockito.verify;
  * This test verifies that the B2StorageClientWebifierImpl translates
  * calls to it into the proper web api calls.
  */
-public class B2StorageClientWebifierImplTest {
+public class B2StorageClientWebifierImplTest extends B2BaseTest {
     private static final String USER_AGENT = "SecretAgentMan/3.19.28";
     private static final String MASTER_URL = "https://api.testb2.com";
 

--- a/core/src/test/java/com/backblaze/b2/client/B2UploadPartUrlCacheTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2UploadPartUrlCacheTest.java
@@ -7,6 +7,7 @@ package com.backblaze.b2.client;
 import com.backblaze.b2.client.exceptions.B2Exception;
 import com.backblaze.b2.client.exceptions.B2InternalErrorException;
 import com.backblaze.b2.client.structures.B2UploadPartUrlResponse;
+import com.backblaze.b2.util.B2BaseTest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -22,7 +23,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-public class B2UploadPartUrlCacheTest {
+public class B2UploadPartUrlCacheTest extends B2BaseTest {
     private static final String LARGE_FILE_ID_1 = "4_zb330e285948b7a6d4b1b0712_f2000000000000001_d20150314_m111111_c001_v1234567_t6789";
     //private static final String LARGE_FILE_ID_2 = "4_zb330e285948b7a6d4b1b0712_f2000000000000002_d20150314_m222222_c001_v1234567_t6789";
 

--- a/core/src/test/java/com/backblaze/b2/client/B2UploadProgressAdapterTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2UploadProgressAdapterTest.java
@@ -4,6 +4,7 @@ package com.backblaze.b2.client;/*
 
 import com.backblaze.b2.client.structures.B2UploadListener;
 import com.backblaze.b2.client.structures.B2UploadProgress;
+import com.backblaze.b2.util.B2BaseTest;
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -15,7 +16,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-public class B2UploadProgressAdapterTest {
+public class B2UploadProgressAdapterTest extends B2BaseTest {
     private final B2UploadListener listener = mock(B2UploadListener.class);
     private final B2UploadProgressAdapter adapter = new B2UploadProgressAdapter(listener, 1, 2, 3, 4);
 

--- a/core/src/test/java/com/backblaze/b2/client/B2UploadProgressUtilTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2UploadProgressUtilTest.java
@@ -3,11 +3,12 @@ package com.backblaze.b2.client;/*
  */
 
 import com.backblaze.b2.client.structures.B2UploadState;
+import com.backblaze.b2.util.B2BaseTest;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class B2UploadProgressUtilTest {
+public class B2UploadProgressUtilTest extends B2BaseTest {
     private static final int PART_COUNT = 10;
     private static final long LENGTH = 100;
     private static final B2PartSpec PART_SPEC = new B2PartSpec(2, 123, LENGTH);

--- a/core/src/test/java/com/backblaze/b2/client/B2UploadUrlCacheTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2UploadUrlCacheTest.java
@@ -7,6 +7,7 @@ package com.backblaze.b2.client;
 import com.backblaze.b2.client.exceptions.B2Exception;
 import com.backblaze.b2.client.exceptions.B2InternalErrorException;
 import com.backblaze.b2.client.structures.B2UploadUrlResponse;
+import com.backblaze.b2.util.B2BaseTest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -24,7 +25,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-public class B2UploadUrlCacheTest {
+public class B2UploadUrlCacheTest extends B2BaseTest {
     private final B2StorageClientWebifier webifier = mock(B2StorageClientWebifier.class);
     private final B2AccountAuthorizationCache authCache = mock(B2AccountAuthorizationCache.class);
 

--- a/core/src/test/java/com/backblaze/b2/client/contentHandlers/B2ContentFileWriterTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/contentHandlers/B2ContentFileWriterTest.java
@@ -4,6 +4,7 @@
  */
 package com.backblaze.b2.client.contentHandlers;
 
+import com.backblaze.b2.util.B2BaseTest;
 import org.junit.Test;
 
 import java.io.File;
@@ -16,7 +17,7 @@ import static org.junit.Assert.assertTrue;
  * actually writing to disk, it doesn't really write to disk.  Bummer, huh?
  * Hopefully there's more exercising of it elsewhere.
  */
-public class B2ContentFileWriterTest {
+public class B2ContentFileWriterTest extends B2BaseTest {
     private File FILE = new File("/tmp/outputFile");
 
     @Test

--- a/core/src/test/java/com/backblaze/b2/client/contentHandlers/B2ContentMemoryWriterTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/contentHandlers/B2ContentMemoryWriterTest.java
@@ -7,6 +7,7 @@ package com.backblaze.b2.client.contentHandlers;
 import com.backblaze.b2.client.contentSources.B2Headers;
 import com.backblaze.b2.client.contentSources.B2HeadersImpl;
 import com.backblaze.b2.client.exceptions.B2Exception;
+import com.backblaze.b2.util.B2BaseTest;
 import com.backblaze.b2.util.B2Sha1;
 import org.junit.Rule;
 import org.junit.Test;
@@ -25,7 +26,7 @@ import static org.junit.Assert.assertTrue;
  * actually writing to disk, it doesn't really write to disk.  Bummer, huh?
  * Hopefully there's more exercising of it elsewhere.
  */
-public class B2ContentMemoryWriterTest {
+public class B2ContentMemoryWriterTest extends B2BaseTest {
     private static final int LEN = 6123;
     private final byte[] bytes = makeBytes(LEN);
     private final ByteArrayInputStream in = new ByteArrayInputStream(bytes);

--- a/core/src/test/java/com/backblaze/b2/client/contentHandlers/B2ContentWriterTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/contentHandlers/B2ContentWriterTest.java
@@ -8,6 +8,7 @@ import com.backblaze.b2.client.B2TestHelpers;
 import com.backblaze.b2.client.contentSources.B2Headers;
 import com.backblaze.b2.client.contentSources.B2HeadersImpl;
 import com.backblaze.b2.client.exceptions.B2Exception;
+import com.backblaze.b2.util.B2BaseTest;
 import com.backblaze.b2.util.B2ByteRange;
 import com.backblaze.b2.util.B2Sha1;
 import org.junit.Rule;
@@ -32,7 +33,7 @@ import static org.junit.Assert.assertTrue;
  * actually writing to disk, it doesn't really write to disk.  Bummer, huh?
  * Hopefully there's more exercising of it elsewhere.
  */
-public class B2ContentWriterTest {
+public class B2ContentWriterTest extends B2BaseTest {
     private static final int LEN = 6123;
 
     private final byte[] bytes = makeBytes(LEN);

--- a/core/src/test/java/com/backblaze/b2/client/contentSources/B2ByteArrayContentSourceTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/contentSources/B2ByteArrayContentSourceTest.java
@@ -4,6 +4,7 @@
  */
 package com.backblaze.b2.client.contentSources;
 
+import com.backblaze.b2.util.B2BaseTest;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
@@ -15,7 +16,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-public class B2ByteArrayContentSourceTest {
+public class B2ByteArrayContentSourceTest extends B2BaseTest {
     private static final byte[] sourceBytes = "Hello, World!".getBytes();
     private static final Long SRC_LAST_MOD_MILLIS = 123456L;
 

--- a/core/src/test/java/com/backblaze/b2/client/contentSources/B2FileContentSourceTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/contentSources/B2FileContentSourceTest.java
@@ -4,6 +4,7 @@
  */
 package com.backblaze.b2.client.contentSources;
 
+import com.backblaze.b2.util.B2BaseTest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -16,7 +17,7 @@ import static com.backblaze.b2.client.B2TestHelpers.SAMPLE_SHA1;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-public class B2FileContentSourceTest {
+public class B2FileContentSourceTest extends B2BaseTest {
     // rather than make a file on disk (and making the unit test depend on the filesystem)
     // i'm just going to try to use a non-existent file and check that i get reasonable
     // exceptions.

--- a/core/src/test/java/com/backblaze/b2/client/contentSources/B2HeadersImplTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/contentSources/B2HeadersImplTest.java
@@ -4,6 +4,7 @@
  */
 package com.backblaze.b2.client.contentSources;
 
+import com.backblaze.b2.util.B2BaseTest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -17,7 +18,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-public class B2HeadersImplTest {
+public class B2HeadersImplTest extends B2BaseTest {
     private static final String SAMPLE_SHA1 = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
     private static final Long   SAMPLE_LAST_MODIFIED_LONG = 1495210502000L;
     private static final String SAMPLE_LAST_MODIFIED = Long.toString(SAMPLE_LAST_MODIFIED_LONG);

--- a/core/src/test/java/com/backblaze/b2/client/exceptions/B2ExceptionTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/exceptions/B2ExceptionTest.java
@@ -4,11 +4,12 @@
  */
 package com.backblaze.b2.client.exceptions;
 
+import com.backblaze.b2.util.B2BaseTest;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class B2ExceptionTest {
+public class B2ExceptionTest extends B2BaseTest {
     private static final String CODE = "test";
     private static final Integer RETRY_AFTER_SECS = 123;
     private static final String MSG = "test message";

--- a/core/src/test/java/com/backblaze/b2/client/structures/B2ErrorStructureTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/structures/B2ErrorStructureTest.java
@@ -4,11 +4,12 @@
  */
 package com.backblaze.b2.client.structures;
 
+import com.backblaze.b2.util.B2BaseTest;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class B2ErrorStructureTest {
+public class B2ErrorStructureTest extends B2BaseTest {
     private static final int STATUS = 407;
     private static final String CODE = "test";
     private static final String MSG = "test message";

--- a/core/src/test/java/com/backblaze/b2/client/structures/B2FileVersionTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/structures/B2FileVersionTest.java
@@ -6,6 +6,7 @@ package com.backblaze.b2.client.structures;
 
 import com.backblaze.b2.client.B2TestHelpers;
 import com.backblaze.b2.client.contentSources.B2ContentTypes;
+import com.backblaze.b2.util.B2BaseTest;
 import com.backblaze.b2.util.B2Collections;
 import org.junit.Test;
 
@@ -16,7 +17,7 @@ import static com.backblaze.b2.client.B2TestHelpers.fileName;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
-public class B2FileVersionTest {
+public class B2FileVersionTest extends B2BaseTest {
 
     @Test
     public void test() {

--- a/core/src/test/java/com/backblaze/b2/client/structures/B2LifecycleRuleTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/structures/B2LifecycleRuleTest.java
@@ -4,13 +4,14 @@
  */
 package com.backblaze.b2.client.structures;
 
+import com.backblaze.b2.util.B2BaseTest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.assertEquals;
 
-public class B2LifecycleRuleTest {
+public class B2LifecycleRuleTest extends B2BaseTest {
     private static final String FILE_PREFIX = "files/";
 
     @Rule

--- a/core/src/test/java/com/backblaze/b2/client/structures/B2PartTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/structures/B2PartTest.java
@@ -4,6 +4,7 @@
  */
 package com.backblaze.b2.client.structures;
 
+import com.backblaze.b2.util.B2BaseTest;
 import org.junit.Test;
 
 import static com.backblaze.b2.client.B2TestHelpers.fileId;
@@ -11,7 +12,7 @@ import static com.backblaze.b2.client.B2TestHelpers.makePart;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
-public class B2PartTest {
+public class B2PartTest extends B2BaseTest {
     @Test
     public void test() {
         B2Part one = makePart(1);

--- a/core/src/test/java/com/backblaze/b2/client/structures/B2UploadProgressTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/structures/B2UploadProgressTest.java
@@ -2,11 +2,12 @@ package com.backblaze.b2.client.structures;/*
  * Copyright 2017, Backblaze, Inc. All rights reserved. 
  */
 
+import com.backblaze.b2.util.B2BaseTest;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class B2UploadProgressTest {
+public class B2UploadProgressTest extends B2BaseTest {
     private final static int PART_INDEX = 1;
     private final static int PART_COUNT = 2;
     private final static long START_BYTE = 3;

--- a/core/src/test/java/com/backblaze/b2/json/B2JsonReaderTest.java
+++ b/core/src/test/java/com/backblaze/b2/json/B2JsonReaderTest.java
@@ -5,6 +5,7 @@
 
 package com.backblaze.b2.json;
 
+import com.backblaze.b2.util.B2BaseTest;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -18,7 +19,7 @@ import static org.junit.Assert.fail;
 /**
  * Unit tests for JsonReader
  */
-public class B2JsonReaderTest {
+public class B2JsonReaderTest extends B2BaseTest {
 
     @Test
     public void testReadNumberAsString() throws IOException, B2JsonException {

--- a/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
+++ b/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
@@ -5,6 +5,7 @@
 
 package com.backblaze.b2.json;
 
+import com.backblaze.b2.util.B2BaseTest;
 import com.backblaze.b2.util.B2Preconditions;
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,7 +42,7 @@ import static org.junit.Assert.fail;
         "unused",  // A lot of the test classes have things that aren't used, but we don't care.
         "WeakerAccess"  // A lot of the test classes could have weaker access, but we don't care.
 })
-public class B2JsonTest {
+public class B2JsonTest extends B2BaseTest {
 
     @Rule
     public ExpectedException thrown  = ExpectedException.none();

--- a/core/src/test/java/com/backblaze/b2/util/B2BaseTest.java
+++ b/core/src/test/java/com/backblaze/b2/util/B2BaseTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018, Backblaze, Inc. All rights reserved. 
+ */
+package com.backblaze.b2.util;
+
+import org.junit.BeforeClass;
+
+import static com.backblaze.b2.util.B2DateTimeUtil.parseDateTime;
+
+/**
+ * This class is the base class for all of our unit tests.
+ * It provides some useful "before" functionality and
+ * it can provide some common helpers if that becomes
+ * useful.
+ */
+public class B2BaseTest {
+    /**
+     * We want to be sure that the unit tests use the simulated clock.
+     * If we don't ensure this, some test might inadvertently create
+     * a real clock and then, when another test wants a clock simulator,
+     * we'll hit an exception saying we're already using a real clock.
+     * So...we pre-emptively create a simulator.
+     */
+    @BeforeClass
+    public static void makeSureTheClockIsSimulator() {
+        B2Clock.useSimulator(parseDateTime("2018-04-27 00:00:00"));
+    }
+}

--- a/core/src/test/java/com/backblaze/b2/util/B2ByteRangeTest.java
+++ b/core/src/test/java/com/backblaze/b2/util/B2ByteRangeTest.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-public class B2ByteRangeTest {
+public class B2ByteRangeTest extends B2BaseTest {
 
     @Test
     public void testStartAt() {

--- a/core/src/test/java/com/backblaze/b2/util/B2ClockImplTest.java
+++ b/core/src/test/java/com/backblaze/b2/util/B2ClockImplTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
 
-public class B2ClockImplTest {
+public class B2ClockImplTest extends B2BaseTest {
 
     @Test
     public void test() throws InterruptedException {

--- a/core/src/test/java/com/backblaze/b2/util/B2ClockSimTest.java
+++ b/core/src/test/java/com/backblaze/b2/util/B2ClockSimTest.java
@@ -14,7 +14,7 @@ import java.time.Duration;
 import static com.backblaze.b2.util.B2DateTimeUtil.ONE_SECOND_IN_MILLIS;
 import static org.junit.Assert.assertEquals;
 
-public class B2ClockSimTest {
+public class B2ClockSimTest extends B2BaseTest{
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 

--- a/core/src/test/java/com/backblaze/b2/util/B2CollectionsTest.java
+++ b/core/src/test/java/com/backblaze/b2/util/B2CollectionsTest.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class B2CollectionsTest {
+public class B2CollectionsTest extends B2BaseTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 

--- a/core/src/test/java/com/backblaze/b2/util/B2DateTimeUtilTest.java
+++ b/core/src/test/java/com/backblaze/b2/util/B2DateTimeUtilTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-public class B2DateTimeUtilTest {
+public class B2DateTimeUtilTest extends B2BaseTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 

--- a/core/src/test/java/com/backblaze/b2/util/B2InputStreamExcerptTest.java
+++ b/core/src/test/java/com/backblaze/b2/util/B2InputStreamExcerptTest.java
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-public class B2InputStreamExcerptTest {
+public class B2InputStreamExcerptTest extends B2BaseTest {
     private static final String DIGITS_STR = "0123456789";
     private static final byte[] DIGITS_BYTES = DIGITS_STR.getBytes();
     private static final int EOF = -1;

--- a/core/src/test/java/com/backblaze/b2/util/B2InputStreamWithByteProgressListenerTest.java
+++ b/core/src/test/java/com/backblaze/b2/util/B2InputStreamWithByteProgressListenerTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-public class B2InputStreamWithByteProgressListenerTest {
+public class B2InputStreamWithByteProgressListenerTest extends B2BaseTest {
     private static final int EOF = -1;
 
     private final InputStream wrappedStream = mock(InputStream.class);

--- a/core/src/test/java/com/backblaze/b2/util/B2IoUtilsTest.java
+++ b/core/src/test/java/com/backblaze/b2/util/B2IoUtilsTest.java
@@ -17,7 +17,7 @@ import static com.backblaze.b2.client.B2TestHelpers.makeBytes;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
-public class B2IoUtilsTest {
+public class B2IoUtilsTest extends B2BaseTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 

--- a/core/src/test/java/com/backblaze/b2/util/B2PreconditionsTest.java
+++ b/core/src/test/java/com/backblaze/b2/util/B2PreconditionsTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class B2PreconditionsTest {
+public class B2PreconditionsTest extends B2BaseTest {
     @Test
     public void test() {
         checkThrows(IllegalArgumentException.class, null, () -> B2Preconditions.checkArgument(false));

--- a/core/src/test/java/com/backblaze/b2/util/B2Sha1AppenderInputStreamTest.java
+++ b/core/src/test/java/com/backblaze/b2/util/B2Sha1AppenderInputStreamTest.java
@@ -13,7 +13,7 @@ import java.io.InputStream;
 
 import static org.junit.Assert.assertEquals;
 
-public class B2Sha1AppenderInputStreamTest {
+public class B2Sha1AppenderInputStreamTest extends B2BaseTest {
     private static final String CONTENTS = "Hello, World!";
     private static final String SHA1 = "0a0a9f2a6772942557ab5355d76af442f8f65e01";
 

--- a/core/src/test/java/com/backblaze/b2/util/B2Sha1InputStreamTest.java
+++ b/core/src/test/java/com/backblaze/b2/util/B2Sha1InputStreamTest.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
-public class B2Sha1InputStreamTest {
+public class B2Sha1InputStreamTest extends B2BaseTest {
 
     @Test
     public void testAllReadMethods() throws IOException {

--- a/core/src/test/java/com/backblaze/b2/util/B2Sha1Test.java
+++ b/core/src/test/java/com/backblaze/b2/util/B2Sha1Test.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class B2Sha1Test {
+public class B2Sha1Test extends B2BaseTest {
 
     @Test
     public void testSha1() throws IOException {

--- a/core/src/test/java/com/backblaze/b2/util/B2StringUtilTest.java
+++ b/core/src/test/java/com/backblaze/b2/util/B2StringUtilTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class B2StringUtilTest {
+public class B2StringUtilTest extends B2BaseTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 

--- a/core/src/test/java/com/backblaze/b2/util/B2Utf8UtilTest.java
+++ b/core/src/test/java/com/backblaze/b2/util/B2Utf8UtilTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class B2Utf8UtilTest {
+public class B2Utf8UtilTest extends B2BaseTest {
 
 
     //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
i was getting a failure recently when running tests from the command
line.  there was an unfortunate ordering which meant sometimes we
ended up with a real clock instead of a simulator and then when a test
that wanted a clock simulator found a real clock, it rightfully failed.

the new B2BaseTest has an @BeforeClass method that ensures that
we'll always have a clock simulator.

tested locally by running "./gradlew build javadoc writeNewPom"