### PR TITLE
exceptions: add default codes for exception classes.

### DIFF
--- a/core/src/main/java/com/backblaze/b2/client/exceptions/B2BadRequestException.java
+++ b/core/src/main/java/com/backblaze/b2/client/exceptions/B2BadRequestException.java
@@ -5,6 +5,7 @@
 package com.backblaze.b2.client.exceptions;
 
 public class B2BadRequestException extends B2Exception {
+    public static final String DEFAULT_CODE = "bad_request";
     public static final int STATUS = 400;
 
     public B2BadRequestException(String code,
@@ -17,6 +18,6 @@ public class B2BadRequestException extends B2Exception {
                                  Integer retryAfterSecondsOrNull,
                                  String message,
                                  Throwable cause) {
-        super(code, STATUS, retryAfterSecondsOrNull, message, cause);
+        super(orIfNull(code, DEFAULT_CODE), STATUS, retryAfterSecondsOrNull, message, cause);
     }
 }

--- a/core/src/main/java/com/backblaze/b2/client/exceptions/B2Exception.java
+++ b/core/src/main/java/com/backblaze/b2/client/exceptions/B2Exception.java
@@ -9,6 +9,7 @@ package com.backblaze.b2.client.exceptions;
  * all B2-specific exceptions thrown by b2-sdk-java.
  */
 public class B2Exception extends Exception {
+    public static final String DEFAULT_CODE = "unknown_code";
     private final String code;
     private final int status;
 
@@ -30,7 +31,7 @@ public class B2Exception extends Exception {
                        String message,
                        Throwable cause) {
         super(message, cause);
-        this.code = code;
+        this.code = orIfNull(code, DEFAULT_CODE);
         this.status = status;
         this.retryAfterSecondsOrNull = retryAfterSecondsOrNull;
     }
@@ -86,5 +87,18 @@ public class B2Exception extends Exception {
             default:
                 return new B2Exception(code, status, retryAfterSecondsOrNull, message);
         }
+    }
+
+    /**
+     * @param orig the preferred return value
+     * @param ifNull what to return if orig is null.
+     * @return ifNull if orig == null, otherwise orig.
+     */
+    static String orIfNull(String orig,
+                           String ifNull) {
+        if (orig != null) {
+            return orig;
+        }
+        return ifNull;
     }
 }

--- a/core/src/main/java/com/backblaze/b2/client/exceptions/B2ForbiddenException.java
+++ b/core/src/main/java/com/backblaze/b2/client/exceptions/B2ForbiddenException.java
@@ -5,6 +5,7 @@
 package com.backblaze.b2.client.exceptions;
 
 public class B2ForbiddenException extends B2Exception {
+    public static final String DEFAULT_CODE = "forbidden";
     public static final int STATUS = 403;
 
     public B2ForbiddenException(String code,
@@ -17,6 +18,6 @@ public class B2ForbiddenException extends B2Exception {
                                 Integer retryAfterSecondsOrNull,
                                 String message,
                                 Throwable cause) {
-        super(code, STATUS, retryAfterSecondsOrNull, message, cause);
+        super(orIfNull(code, DEFAULT_CODE), STATUS, retryAfterSecondsOrNull, message, cause);
     }
 }

--- a/core/src/main/java/com/backblaze/b2/client/exceptions/B2InternalErrorException.java
+++ b/core/src/main/java/com/backblaze/b2/client/exceptions/B2InternalErrorException.java
@@ -5,11 +5,11 @@
 package com.backblaze.b2.client.exceptions;
 
 public class B2InternalErrorException extends B2Exception {
-    public static final String CODE = "internal_error";
+    public static final String DEFAULT_CODE = "internal_error";
     public static final int STATUS = 500;
 
     public B2InternalErrorException(String message) {
-        this(CODE, message);
+        this(DEFAULT_CODE, message);
     }
     public B2InternalErrorException(String code,
                                     String message) {
@@ -26,6 +26,6 @@ public class B2InternalErrorException extends B2Exception {
                                     Integer retryAfterSecondsOrNull,
                                     String message,
                                     Throwable cause) {
-        super(code, STATUS, retryAfterSecondsOrNull, message, cause);
+        super(orIfNull(code, DEFAULT_CODE), STATUS, retryAfterSecondsOrNull, message, cause);
     }
 }

--- a/core/src/main/java/com/backblaze/b2/client/exceptions/B2NotFoundException.java
+++ b/core/src/main/java/com/backblaze/b2/client/exceptions/B2NotFoundException.java
@@ -5,12 +5,12 @@
 package com.backblaze.b2.client.exceptions;
 
 public class B2NotFoundException extends B2Exception {
-    public static final String CODE = "not_found";
+    public static final String DEFAULT_CODE = "not_found";
     public static final int STATUS = 404;
 
     public B2NotFoundException(Integer retryAfterSecondsOrNull,
                                String message) {
-        this(CODE, retryAfterSecondsOrNull, message);
+        this(DEFAULT_CODE, retryAfterSecondsOrNull, message);
     }
 
     public B2NotFoundException(String code,
@@ -23,6 +23,6 @@ public class B2NotFoundException extends B2Exception {
                                Integer retryAfterSecondsOrNull,
                                String message,
                                Throwable cause) {
-        super(code, STATUS, retryAfterSecondsOrNull, message, cause);
+        super(orIfNull(code, DEFAULT_CODE), STATUS, retryAfterSecondsOrNull, message, cause);
     }
 }

--- a/core/src/main/java/com/backblaze/b2/client/exceptions/B2RequestTimeoutException.java
+++ b/core/src/main/java/com/backblaze/b2/client/exceptions/B2RequestTimeoutException.java
@@ -5,6 +5,7 @@
 package com.backblaze.b2.client.exceptions;
 
 public class B2RequestTimeoutException extends B2Exception {
+    public static final String DEFAULT_CODE = "request_timeout";
     public static final int STATUS = 408;
 
     public B2RequestTimeoutException(String code,
@@ -17,6 +18,6 @@ public class B2RequestTimeoutException extends B2Exception {
                                      Integer retryAfterSecondsOrNull,
                                      String message,
                                      Throwable cause) {
-        super(code, STATUS, retryAfterSecondsOrNull, message, cause);
+        super(orIfNull(code, DEFAULT_CODE), STATUS, retryAfterSecondsOrNull, message, cause);
     }
 }

--- a/core/src/main/java/com/backblaze/b2/client/exceptions/B2ServiceUnavailableException.java
+++ b/core/src/main/java/com/backblaze/b2/client/exceptions/B2ServiceUnavailableException.java
@@ -5,6 +5,7 @@
 package com.backblaze.b2.client.exceptions;
 
 public class B2ServiceUnavailableException extends B2Exception {
+    public static final String DEFAULT_CODE = "service_unavailable";
     public static final int STATUS = 503;
 
     public B2ServiceUnavailableException(String code,
@@ -17,6 +18,6 @@ public class B2ServiceUnavailableException extends B2Exception {
                                          Integer retryAfterSecondsOrNull,
                                          String message,
                                          Throwable cause) {
-        super(code, STATUS, retryAfterSecondsOrNull, message, cause);
+        super(orIfNull(code, DEFAULT_CODE), STATUS, retryAfterSecondsOrNull, message, cause);
     }
 }

--- a/core/src/main/java/com/backblaze/b2/client/exceptions/B2TooManyRequestsException.java
+++ b/core/src/main/java/com/backblaze/b2/client/exceptions/B2TooManyRequestsException.java
@@ -5,6 +5,7 @@
 package com.backblaze.b2.client.exceptions;
 
 public class B2TooManyRequestsException extends B2Exception {
+    public static final String DEFAULT_CODE = "too_many_requests";
     public static final int STATUS = 429;
 
 
@@ -16,6 +17,6 @@ public class B2TooManyRequestsException extends B2Exception {
                                       Integer retryAfterSecondsOrNull,
                                       String message,
                                       Throwable cause) {
-        super(code, STATUS, retryAfterSecondsOrNull, message, cause);
+        super(orIfNull(code, DEFAULT_CODE), STATUS, retryAfterSecondsOrNull, message, cause);
     }
 }

--- a/core/src/main/java/com/backblaze/b2/client/exceptions/B2UnauthorizedException.java
+++ b/core/src/main/java/com/backblaze/b2/client/exceptions/B2UnauthorizedException.java
@@ -5,6 +5,7 @@
 package com.backblaze.b2.client.exceptions;
 
 public class B2UnauthorizedException extends B2Exception {
+    public static final String DEFAULT_CODE = "unauthorized";
     public static final int STATUS = 401;
 
     // XXX: ideally this would be "jar private" so far so that only
@@ -31,7 +32,7 @@ public class B2UnauthorizedException extends B2Exception {
                                    Integer retryAfterSecondsOrNull,
                                    String message,
                                    Throwable cause) {
-        super(code, STATUS, retryAfterSecondsOrNull, message, cause);
+        super(orIfNull(code, DEFAULT_CODE), STATUS, retryAfterSecondsOrNull, message, cause);
     }
 
     public RequestCategory getRequestCategory() {

--- a/core/src/test/java/com/backblaze/b2/client/exceptions/B2ExceptionTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/exceptions/B2ExceptionTest.java
@@ -16,27 +16,45 @@ public class B2ExceptionTest extends B2BaseTest {
 
     @Test
     public void testCreate() {
-        checkCreate(B2NotFoundException.STATUS,           B2NotFoundException.class);
-        checkCreate(B2BadRequestException.STATUS,         B2BadRequestException.class);
-        checkCreate(B2UnauthorizedException.STATUS,       B2UnauthorizedException.class);
-        checkCreate(B2ForbiddenException.STATUS,          B2ForbiddenException.class);
-        checkCreate(B2RequestTimeoutException.STATUS,     B2RequestTimeoutException.class);
-        checkCreate(B2TooManyRequestsException.STATUS,    B2TooManyRequestsException.class);
-        checkCreate(B2InternalErrorException.STATUS,      B2InternalErrorException.class);
-        checkCreate(B2ServiceUnavailableException.STATUS, B2ServiceUnavailableException.class);
-        checkCreate(666,                           B2Exception.class);
+        checkCreate(B2NotFoundException.STATUS,           B2NotFoundException.class,           B2NotFoundException.DEFAULT_CODE);
+        checkCreate(B2BadRequestException.STATUS,         B2BadRequestException.class,         B2BadRequestException.DEFAULT_CODE);
+        checkCreate(B2UnauthorizedException.STATUS,       B2UnauthorizedException.class,       B2UnauthorizedException.DEFAULT_CODE);
+        checkCreate(B2ForbiddenException.STATUS,          B2ForbiddenException.class,          B2ForbiddenException.DEFAULT_CODE);
+        checkCreate(B2RequestTimeoutException.STATUS,     B2RequestTimeoutException.class,     B2RequestTimeoutException.DEFAULT_CODE);
+        checkCreate(B2TooManyRequestsException.STATUS,    B2TooManyRequestsException.class,    B2TooManyRequestsException.DEFAULT_CODE);
+        checkCreate(B2InternalErrorException.STATUS,      B2InternalErrorException.class,      B2InternalErrorException.DEFAULT_CODE);
+        checkCreate(B2ServiceUnavailableException.STATUS, B2ServiceUnavailableException.class, B2ServiceUnavailableException.DEFAULT_CODE);
+        checkCreate(666,                           B2Exception.class,                   B2Exception.DEFAULT_CODE);
     }
 
     private void checkCreate(int status,
-                             Class<?> clazz) {
-        final B2Exception e = B2Exception.create(CODE, status, RETRY_AFTER_SECS, MSG);
-        assertEquals(clazz, e.getClass());
+                             Class<?> clazz,
+                             String expectedDefaultCode) {
+        // test with a non-null code.
+        {
+            final B2Exception e = B2Exception.create(CODE, status, RETRY_AFTER_SECS, MSG);
+            assertEquals(clazz, e.getClass());
 
-        assertEquals(CODE, e.getCode());
-        assertEquals(status, e.getStatus());
-        assertEquals(RETRY_AFTER_SECS, e.getRetryAfterSecondsOrNull());
-        assertEquals(MSG, e.getMessage());
+            assertEquals(CODE, e.getCode());
+            assertEquals(status, e.getStatus());
+            assertEquals(RETRY_AFTER_SECS, e.getRetryAfterSecondsOrNull());
+            assertEquals(MSG, e.getMessage());
+        }
+
+        // test with a null code and an empty message.
+        // B2Exception.create gets a code=null sometimes.
+        // In particular, it gets null for failures with HEAD calls.
+        {
+            final B2Exception e = B2Exception.create(null, status, RETRY_AFTER_SECS, "");
+            assertEquals(clazz, e.getClass());
+
+            assertEquals(expectedDefaultCode, e.getCode());
+            assertEquals(status, e.getStatus());
+            assertEquals(RETRY_AFTER_SECS, e.getRetryAfterSecondsOrNull());
+            assertEquals("", e.getMessage());
+        }
     }
+
 
     @Test
     public void testNetworkException() {
@@ -55,10 +73,9 @@ public class B2ExceptionTest extends B2BaseTest {
         final B2Exception e = new B2NotFoundException(RETRY_AFTER_SECS, MSG);
         assertEquals("<B2Exception 404 not_found: test message>", e.toString());
 
-        assertEquals(B2NotFoundException.CODE, e.getCode());
+        assertEquals(B2NotFoundException.DEFAULT_CODE, e.getCode());
         assertEquals(B2NotFoundException.STATUS, e.getStatus());
         assertEquals(RETRY_AFTER_SECS, e.getRetryAfterSecondsOrNull());
         assertEquals(MSG, e.getMessage());
     }
-
 }


### PR DESCRIPTION
this will help when we're creating exceptions from HEAD results, which
don't have a body with the custom error 'code' (or message) from the
server.

conceptual review by brianb.

tested with "./gradlew build javadoc writeNewPom" using new test cases.