### PR TITLE
B2Headers: fix extraction of fileInfos.

### DIFF
--- a/core/src/main/java/com/backblaze/b2/client/contentSources/B2Headers.java
+++ b/core/src/main/java/com/backblaze/b2/client/contentSources/B2Headers.java
@@ -10,6 +10,8 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.TreeMap;
 
+import static com.backblaze.b2.util.B2StringUtil.startsWithIgnoreCase;
+
 /**
  * B2Headers represents the HTTP headers that come with a response from the server.
  */
@@ -129,7 +131,7 @@ public interface B2Headers {
     default Map<String,String> getB2FileInfo() {
         final Map<String,String> info = new TreeMap<>();
         for (String name : getNames()) {
-            if (name.startsWith(FILE_INFO_PREFIX)) {
+            if (startsWithIgnoreCase(name, FILE_INFO_PREFIX)) {
                 final String shortName = name.substring(FILE_INFO_PREFIX.length());
                 info.put(shortName, getValueOrNull(name));
             }

--- a/core/src/main/java/com/backblaze/b2/util/B2StringUtil.java
+++ b/core/src/main/java/com/backblaze/b2/util/B2StringUtil.java
@@ -156,6 +156,25 @@ public class B2StringUtil {
         return sb.toString();
     }
 
+    /**
+     * @param all the string whose prefix we're checking
+     * @param possiblePrefix the prefix we're asking about being in all.
+     * @return true iff both all and possiblePrefix are non-null and
+     *                  all starts with possiblePrefix ignoring case.
+     */
+    public static boolean startsWithIgnoreCase(String all, String possiblePrefix) {
+        if (all == null || possiblePrefix == null) {
+            return false;  // by specification of this method.
+        }
+        if (all.length() < possiblePrefix.length()) {
+            return false;  // too short to have the prefix
+        }
+
+        // we have to actually check the prefix.
+        final String prefix = all.substring(0, possiblePrefix.length());
+        return prefix.equalsIgnoreCase(possiblePrefix);
+    }
+
 
     // this exists so it can be called for code coverage purposes in the unit test.
     // it is package-private so that no one else can call it.

--- a/core/src/test/java/com/backblaze/b2/client/contentSources/B2HeadersImplTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/contentSources/B2HeadersImplTest.java
@@ -39,7 +39,7 @@ public class B2HeadersImplTest extends B2BaseTest {
                 .set(B2Headers.SRC_LAST_MODIFIED_MILLIS, SAMPLE_LAST_MODIFIED)
                 .set(B2Headers.CONTENT_SHA1, SAMPLE_SHA1)
                 .set(B2Headers.FILE_INFO_PREFIX + "alphabet", "abc")
-                .set(B2Headers.FILE_INFO_PREFIX + "zoo", "san diego")
+                .set(B2Headers.FILE_INFO_PREFIX.toLowerCase() + "zoo", "san diego")
                 .build();
     }
 
@@ -55,7 +55,7 @@ public class B2HeadersImplTest extends B2BaseTest {
                 B2Headers.CONTENT_SHA1,
                 B2Headers.FILE_INFO_PREFIX + "alphabet",
                 B2Headers.SRC_LAST_MODIFIED_MILLIS,
-                B2Headers.FILE_INFO_PREFIX + "zoo");
+                B2Headers.FILE_INFO_PREFIX.toLowerCase() + "zoo");
         assertEquals(expectedNames, new ArrayList<>(headers.getNames()));
     }
 

--- a/core/src/test/java/com/backblaze/b2/util/B2StringUtilTest.java
+++ b/core/src/test/java/com/backblaze/b2/util/B2StringUtilTest.java
@@ -15,9 +15,11 @@ import static com.backblaze.b2.util.B2StringUtil.getUtf8Bytes;
 import static com.backblaze.b2.util.B2StringUtil.isEmpty;
 import static com.backblaze.b2.util.B2StringUtil.join;
 import static com.backblaze.b2.util.B2StringUtil.percentEncode;
+import static com.backblaze.b2.util.B2StringUtil.startsWithIgnoreCase;
 import static com.backblaze.b2.util.B2StringUtil.toHexString;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class B2StringUtilTest extends B2BaseTest {
@@ -93,6 +95,29 @@ public class B2StringUtilTest extends B2BaseTest {
         assertEquals("", toHexString(null));
         assertEquals("", toHexString(new byte[0]));
         assertEquals("abf0", toHexString(new byte[] {(byte) 0xab, (byte) 0xf0}));
+    }
+
+    @Test
+    public void testStartsWithIgnoreCase() {
+
+        // cases with nulls
+        assertFalse(startsWithIgnoreCase(null, "prefix"));
+        assertFalse(startsWithIgnoreCase("all", null));
+        assertFalse(startsWithIgnoreCase(null, null));
+
+        // cases where all is too short to possibly contain the prefix.
+        assertFalse(startsWithIgnoreCase("", "prefix"));
+        assertFalse(startsWithIgnoreCase("prefi", "prefix"));
+
+        // cases where it's just not the right prefix
+        assertFalse(startsWithIgnoreCase("real", "fake"));
+        assertFalse(startsWithIgnoreCase("real", "read"));
+
+        // cases where it's the right prefix, even with different cases.
+        assertTrue(startsWithIgnoreCase("real", "real"));
+        assertTrue(startsWithIgnoreCase("really", "real"));
+        assertTrue(startsWithIgnoreCase("REALly", "real"));
+        assertTrue(startsWithIgnoreCase("REALly", "ReAl"));
     }
 
     @Test


### PR DESCRIPTION
i was using String.startsWith() to look headers whose name startsWith
"X-Bz-Info-" prefix.  however, headers are case-insensitive, so i needed
to change it to B2StringUtil.startsWithIgnoreCase.

of course, i had to implement startsWithIgnoreCase() and test it first.  :)
i also updated B2HeadersImplTest so it would fail without this fix, verified
it failed, and then applied the fix and verified it worked.

thanks to valenpo for running into this problem in one of his pull requests. :)

built & tested with "./gradlew build javadoc writeNewPom".

i also ran the sample.