### PR TITLE
These changes are in reference to application key work.

### DIFF
--- a/core/src/main/java/com/backblaze/b2/client/B2AccountAuthorizationCache.java
+++ b/core/src/main/java/com/backblaze/b2/client/B2AccountAuthorizationCache.java
@@ -5,6 +5,7 @@
 package com.backblaze.b2.client;
 
 import com.backblaze.b2.client.exceptions.B2Exception;
+import com.backblaze.b2.client.exceptions.B2LocalException;
 import com.backblaze.b2.client.structures.B2AccountAuthorization;
 
 /**
@@ -19,6 +20,14 @@ class B2AccountAuthorizationCache {
     private final B2StorageClientWebifier webifier;
     private final B2AccountAuthorizer accountAuthorizer;
     private B2AccountAuthorization authorization;
+
+    /**
+     * The authorize() call from the authorizer should always
+     * return an authorization for the same account. After
+     * the first successful authorization, we hold on to the accountId
+     * and use it to make sure we are always authenticating with the same account.
+     */
+    private String accountId;
 
     B2AccountAuthorizationCache(B2StorageClientWebifier webifier,
                                 B2AccountAuthorizer accountAuthorizer) {
@@ -39,8 +48,31 @@ class B2AccountAuthorizationCache {
     synchronized B2AccountAuthorization get() throws B2Exception {
         if (authorization == null) {
             authorization = accountAuthorizer.authorize(webifier);
+
+            final String accountIdFromAuthorization = authorization.getAccountId();
+            if (accountId == null) {
+                accountId = accountIdFromAuthorization;
+            } else {
+                if (!accountId.equals(accountIdFromAuthorization)) {
+                    throw new B2LocalException("unauthorized", "authorized as " + accountIdFromAuthorization +
+                            "but previously authroized as accountId " + accountId);
+                }
+            }
         }
         return authorization;
+    }
+
+    /**
+     * Gets the stored accountId saved by authorizing.
+     * If null, calls get() which does and authorization to get the accountId.
+     * @return the accountId from a successful authorization
+     * @throws B2Exception thrown from any B2Exception thrown during 'authorization' -> get()
+     */
+    synchronized String getAccountId() throws B2Exception{
+        if (accountId == null) {
+            get();
+        }
+        return accountId;
     }
 
     synchronized void clear() {

--- a/core/src/main/java/com/backblaze/b2/client/B2AccountAuthorizer.java
+++ b/core/src/main/java/com/backblaze/b2/client/B2AccountAuthorizer.java
@@ -15,11 +15,6 @@ import com.backblaze.b2.client.structures.B2AccountAuthorization;
  */
 public interface B2AccountAuthorizer {
     /**
-     * @return the accountId whose authorization this returns.
-     */
-    String getAccountId();
-
-    /**
      * This will be called to get a new B2AccountAuthorization instance.
      *
      * @param webifier in case it's useful.  :)

--- a/core/src/main/java/com/backblaze/b2/client/B2AccountAuthorizerSimpleImpl.java
+++ b/core/src/main/java/com/backblaze/b2/client/B2AccountAuthorizerSimpleImpl.java
@@ -25,11 +25,6 @@ public class B2AccountAuthorizerSimpleImpl implements B2AccountAuthorizer {
         this.applicationKey = applicationKey;
     }
 
-    @Override
-    public String getAccountId() {
-        return accountId;
-    }
-
     public static Builder builder(String accountId,
                                   String applicationKey) {
         return new Builder(accountId, applicationKey);

--- a/core/src/test/java/com/backblaze/b2/client/B2AccountAuthorizationCacheTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2AccountAuthorizationCacheTest.java
@@ -6,6 +6,7 @@ package com.backblaze.b2.client;
 
 import com.backblaze.b2.client.exceptions.B2Exception;
 import com.backblaze.b2.client.exceptions.B2InternalErrorException;
+import com.backblaze.b2.client.exceptions.B2LocalException;
 import com.backblaze.b2.client.structures.B2AccountAuthorization;
 import com.backblaze.b2.util.B2BaseTest;
 import org.junit.Rule;
@@ -13,7 +14,9 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import static com.backblaze.b2.client.B2TestHelpers.makeAuth;
+import static com.backblaze.b2.client.B2TestHelpers.makeAuthWithAccountId;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.doReturn;
@@ -26,6 +29,8 @@ public class B2AccountAuthorizationCacheTest extends B2BaseTest {
     private final B2StorageClientWebifier webifier = mock(B2StorageClientWebifier.class);
     private final B2AccountAuthorizer authorizer = mock(B2AccountAuthorizer.class);
 
+    private final String accountId = "accountId";
+
     private final B2AccountAuthorizationCache cache = new B2AccountAuthorizationCache(webifier, authorizer);
 
     @Rule
@@ -34,26 +39,34 @@ public class B2AccountAuthorizationCacheTest extends B2BaseTest {
     @Test
     public void testCache() throws B2Exception {
         // make the authorizer return auth1. and verify we get it.
-        final B2AccountAuthorization auth1 = makeAuth(1);
+        final B2AccountAuthorization auth1 = makeAuthWithAccountId(accountId, 1);
         doReturn(auth1).when(authorizer).authorize(webifier);
         assertTrue(cache.get() == auth1);
 
         // now make the authorizer return auth2 when it gets called.
-        final B2AccountAuthorization auth2 = makeAuth(2);
+        final B2AccountAuthorization auth2 = makeAuthWithAccountId(accountId, 2);
         doReturn(auth2).when(authorizer).authorize(webifier);
 
         // we should keep getting auth1...because we're not calling the authorizer again.
         {
             assertTrue(cache.get() == auth1);
+            assertEquals(auth1.getAccountId(), cache.getAccountId());
             assertTrue(cache.get() == auth1);
+            assertEquals(auth1.getAccountId(), cache.getAccountId());
             assertTrue(cache.get() == auth1);
+            assertEquals(auth1.getAccountId(), cache.getAccountId());
 
             // ...we have still only called the authorizer once!
             verify(authorizer, times(1)).authorize(webifier);
         }
 
         // clearing the cache should cause us to fetch again on the next get().
+        // note: clearing the cache does NOT change or reset the accountID
         cache.clear();
+
+        //cache accountId survives clearing
+        assertTrue(cache.getAccountId().equals(accountId));
+        verify(authorizer, times(1)).authorize(webifier);
 
         // now we should keep getting auth2...
         {
@@ -62,9 +75,46 @@ public class B2AccountAuthorizationCacheTest extends B2BaseTest {
             assertTrue(cache.get() == auth2);
             assertTrue(cache.get() == auth2);
 
+            // accountId from cache matches both authorization calls
+            assertTrue(cache.getAccountId().equals(auth1.getAccountId()));
+            assertTrue(cache.getAccountId().equals(auth2.getAccountId()));
+
+            // but the actual auth should not be equal, since we made a new call
+            assertFalse(cache.get() == auth1);
+
             // ...and only have called the authorizer one more time!
             verify(authorizer, times(2)).authorize(webifier);
         }
+    }
+
+    @Test
+    public void testMismatchAccountId() throws B2Exception {
+        final B2AccountAuthorization auth1 = makeAuthWithAccountId(accountId, 1);
+        doReturn(auth1).when(authorizer).authorize(webifier);
+        assertTrue(cache.get() == auth1);
+
+        //clear to force another authorize()
+        cache.clear();
+
+        thrown.expect(B2LocalException .class);
+        final B2AccountAuthorization auth2 = makeAuthWithAccountId("anotherAccountId", 2);
+        doReturn(auth2).when(authorizer).authorize(webifier);
+
+        //throws because accountId's mismatch
+        cache.get();
+
+    }
+
+    @Test
+    public void testGetAccountIdCallsGet() throws B2Exception {
+        final B2AccountAuthorization auth1 = makeAuthWithAccountId(accountId, 1);
+        doReturn(auth1).when(authorizer).authorize(webifier);
+        assertTrue(cache.getAccountId().equals(accountId));
+        verify(authorizer, times(1)).authorize(webifier);
+
+        //verify we only called authorize once when getting the accountId
+        assertTrue(cache.getAccountId().equals(accountId));
+        verify(authorizer, times(1)).authorize(webifier);
     }
 
     @Test

--- a/core/src/test/java/com/backblaze/b2/client/B2ClientConfigTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2ClientConfigTest.java
@@ -5,7 +5,6 @@
 package com.backblaze.b2.client;
 
 import com.backblaze.b2.client.exceptions.B2Exception;
-import com.backblaze.b2.client.structures.B2AccountAuthorization;
 import com.backblaze.b2.client.structures.B2AuthorizeAccountRequest;
 import com.backblaze.b2.util.B2BaseTest;
 import org.junit.Test;
@@ -21,16 +20,8 @@ import static org.mockito.Mockito.verify;
 
 public class B2ClientConfigTest extends B2BaseTest {
     private static final String USER_AGENT = "B2ClientConfigTest/0.0.1";
-    private final B2AccountAuthorizer AUTHORIZER = new B2AccountAuthorizer() {
-        @Override
-        public String getAccountId() {
-            throw new RuntimeException("not expected to be called!");
-        }
-
-        @Override
-        public B2AccountAuthorization authorize(B2StorageClientWebifier webifier) throws B2Exception {
-            throw new RuntimeException("not expected to be called!");
-        }
+    private final B2AccountAuthorizer AUTHORIZER = webifier -> {
+        throw new RuntimeException("not expected to be called!");
     };
 
 
@@ -68,7 +59,6 @@ public class B2ClientConfigTest extends B2BaseTest {
 
         final B2AccountAuthorizer authorizer = config.getAccountAuthorizer();
         assertTrue(authorizer instanceof B2AccountAuthorizerSimpleImpl);
-        assertEquals("accountId", authorizer.getAccountId());
 
         B2StorageClientWebifier webifier = mock(B2StorageClientWebifier.class);
         authorizer.authorize(webifier);

--- a/core/src/test/java/com/backblaze/b2/client/B2TestHelpers.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2TestHelpers.java
@@ -19,7 +19,6 @@ import com.backblaze.b2.client.structures.B2UploadUrlResponse;
 import com.backblaze.b2.util.B2Clock;
 import com.backblaze.b2.util.B2Collections;
 import com.backblaze.b2.util.B2Sha1;
-import com.backblaze.b2.util.B2StringUtil;
 
 import java.util.Collections;
 
@@ -53,7 +52,12 @@ public class B2TestHelpers {
      * @return a new B2AccountAuthorization, with bogus-but-recognizable values based on i.
      */
     public static B2AccountAuthorization makeAuth(int i) {
-        return new B2AccountAuthorization(Integer.toString(i),
+        return makeAuthWithAccountId(Integer.toString(i), i);
+    }
+
+    public static B2AccountAuthorization makeAuthWithAccountId(String accountId , int i) {
+        return new B2AccountAuthorization(
+                accountId,
                 "accountToken" + i,
                 "apiUrl" + i,
                 "downloadUrl" + i,


### PR DESCRIPTION
We used to memorize the accountId passed into the AccountAuthorizer,
however that doesn't work when using applicationKeyId's to authenticate.

So in order for the SDK to work with the new Application Keys
we now store the accountId in the B2AccountAuthorizationCache after
successfully authorizing.

The changes were removing the B2Authorizer getAccount() method,
and calling getAccountId() from the cache, either with retries or not.

Updated Tests, passes All Tests in core and works with B2Sample.java
when pointed at staging where Application Key API's are turned on.

**ApplicationKeys are still not available in production.