### PR TITLE
unions: support serializing objects containing unions.

### DIFF
--- a/core/src/main/java/com/backblaze/b2/json/B2JsonUnionBaseHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonUnionBaseHandler.java
@@ -243,7 +243,9 @@ public class B2JsonUnionBaseHandler<T> extends B2JsonNonUrlTypeHandler<T> {
                         throw new B2JsonException("unknown field '" + fieldName + "' in union type " + clazz.getSimpleName());
                     }
                     else {
-                        fieldNameToValue.put(fieldName, handler.deserialize(in, options));
+                        // we allow all fields to be parsed as null here.
+                        // if it's a required field, we detect that in deserializeFromFieldNameToValueMap().
+                        fieldNameToValue.put(fieldName, B2JsonUtil.deserializeMaybeNull(handler, in, options));
                     }
                 }
             } while (in.objectHasMoreFields());

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonUnionBaseHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonUnionBaseHandler.java
@@ -40,6 +40,11 @@ public class B2JsonUnionBaseHandler<T> extends B2JsonNonUrlTypeHandler<T> {
     private final Map<String, B2JsonObjectHandler<?>> typeNameToHandler;
 
     /**
+     * Mapping from registered classes to their handlers.
+     */
+    private final Map<Class<?>, B2JsonObjectHandler<?>> classToHandler;
+
+    /**
      * Handlers for all of the fields in all of the subclasses.
      *
      * The rule is that in all of the subclasses of a union base class, all fields
@@ -79,17 +84,19 @@ public class B2JsonUnionBaseHandler<T> extends B2JsonNonUrlTypeHandler<T> {
         // Get the map of type name to class of all the members of the union.
         final Map<String, Class<?>> typeNameToClass = getUnionTypeMap(clazz).getTypeNameToClass();
 
-        // Build the map from type name to handler.
+        // Build the maps from type name and class to handler.
         typeNameToHandler = new HashMap<>();
+        classToHandler = new HashMap<>();
         for (Map.Entry<String, Class<?>> entry : typeNameToClass.entrySet()) {
             final String typeName = entry.getKey();
             final Class<?> typeClass = entry.getValue();
-            if (!hasSuperclass(typeClass, clazz)) {
+            if (!hasSuperclass(typeClass, clazz)) { // use clazz.isAssignableFrom(typeClass)?
                 throw new B2JsonException(typeClass + " is not a subclass of " + clazz);
             }
             final B2JsonTypeHandler<?> handler = handlerMap.getHandler(typeClass);
             if (handler instanceof B2JsonObjectHandler) {
                 typeNameToHandler.put(typeName, (B2JsonObjectHandler) handler);
+                classToHandler.put(typeClass, (B2JsonObjectHandler) handler);
             }
             else {
                 throw new B2JsonException("BUG: handler for subclass of union is not B2JsonObjectHandler");
@@ -198,7 +205,24 @@ public class B2JsonUnionBaseHandler<T> extends B2JsonNonUrlTypeHandler<T> {
 
     @Override
     public void serialize(T obj, B2JsonWriter out) throws IOException, B2JsonException {
-        throw new B2JsonException("" + clazz + " is a union base class, and cannot be serialized");
+        if (obj.getClass() == clazz) {
+            // the union base class is basically "abstract" and can't be serialized.
+            throw new B2JsonException("" + clazz + " is a union base class, and cannot be serialized");
+        }
+
+        //
+        // we need to use the handler for obj's class to serialize obj.
+        //
+
+        // look in our map for the handler.
+        //noinspection unchecked
+        final B2JsonObjectHandler<T> objHandler = (B2JsonObjectHandler<T>) classToHandler.get(obj.getClass());
+        if (objHandler == null) {
+            throw new B2JsonException("" + obj.getClass() + " isn't a registered part of union " + clazz);
+        }
+
+        // we have the right handler, so make it do the work.
+        objHandler.serialize(obj, out);
     }
 
     @Override

--- a/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
+++ b/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
@@ -1740,4 +1740,65 @@ public class B2JsonTest extends B2BaseTest {
 
     private static class SubclassF extends UnionF {
     }
+
+
+    @Test
+    public void testUnionSubclassHasNullOptionalField() throws B2JsonException, IOException {
+        final String json = "{\n" +
+                "  \"name\": null,\n" +
+                "  \"type\": \"g\"\n" +
+                "}";
+        checkDeserializeSerialize(json, UnionG.class);
+    }
+
+    @B2Json.union(typeField = "type")
+    private static class UnionG {
+        public static B2JsonUnionTypeMap getUnionTypeMap() throws B2JsonException {
+            return B2JsonUnionTypeMap
+                    .builder()
+                    .put("g", SubclassG.class)
+                    .build();
+        }
+    }
+
+    private static class SubclassG extends UnionG {
+        @B2Json.optional
+        final String name;
+
+        @B2Json.constructor(params = "name")
+        private SubclassG(String name) {
+            this.name = name;
+        }
+    }
+
+    @Test
+    public void testUnionSubclassHasNullRequiredField() throws B2JsonException, IOException {
+        final String json = "{\n" +
+                "  \"name\": null,\n" +
+                "  \"type\": \"h\"\n" +
+                "}";
+        thrown.expectMessage("required field name cannot be null");
+        checkDeserializeSerialize(json, UnionH.class);
+    }
+
+    @B2Json.union(typeField = "type")
+    private static class UnionH {
+        public static B2JsonUnionTypeMap getUnionTypeMap() throws B2JsonException {
+            return B2JsonUnionTypeMap
+                    .builder()
+                    .put("h", SubclassH.class)
+                    .build();
+        }
+    }
+
+    private static class SubclassH extends UnionH {
+        @B2Json.required
+        final String name;
+
+        @B2Json.constructor(params = "name")
+        private SubclassH(String name) {
+            this.name = name;
+        }
+    }
+
 }

--- a/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
+++ b/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
@@ -1479,6 +1479,33 @@ public class B2JsonTest extends B2BaseTest {
         B2Json.get().fromJson(json, UnionAZ.class);
     }
 
+    @Test
+    public void testSerializeUnionSubType() throws B2JsonException, IOException {
+        final String origJson = "{\n" +
+                "  \"contained\": {\n" +
+                "    \"a\": 1,\n" +
+                "    \"type\": \"a\"\n" +
+                "  }\n" +
+                "}";
+        checkDeserializeSerialize(origJson, ContainsUnion.class);
+    }
+
+    @Test
+    public void testSerializeOptionalAndMissingUnion() throws B2JsonException, IOException {
+        final String origJson = "{\n" +
+                "  \"contained\": null\n" +
+                "}";
+        checkDeserializeSerialize(origJson, ContainsOptionalUnion.class);
+    }
+
+    @Test
+    public void testSerializeUnregisteredUnionSubType() throws B2JsonException {
+        final SubclassUnregistered unregistered = new SubclassUnregistered("zzz");
+        final ContainsUnion container = new ContainsUnion(unregistered);
+        thrown.expectMessage("class com.backblaze.b2.json.B2JsonTest$SubclassUnregistered isn't a registered part of union class com.backblaze.b2.json.B2JsonTest$UnionAZ");
+        B2Json.get().toJson(container);
+    }
+
     @B2Json.union(typeField = "type")
     private static class UnionAZ {
         public static B2JsonUnionTypeMap getUnionTypeMap() throws B2JsonException {
@@ -1507,6 +1534,38 @@ public class B2JsonTest extends B2BaseTest {
         @B2Json.constructor(params = "z")
         private SubclassZ(String z) {
             this.z = z;
+        }
+    }
+
+    private static class SubclassUnregistered extends UnionAZ {
+        @B2Json.required
+        public final String u;
+
+        @B2Json.constructor(params = "u")
+        private SubclassUnregistered(String u) {
+            this.u = u;
+        }
+    }
+
+    // i *soooo* wanted to call this class "North",
+    // but the more boring name "ContainsUnion" is clearer.
+    private static class ContainsUnion {
+        @B2Json.required
+        private final UnionAZ contained;
+
+        @B2Json.constructor(params = "contained")
+        private ContainsUnion(UnionAZ contained) {
+            this.contained = contained;
+        }
+    }
+
+    private static class ContainsOptionalUnion {
+        @B2Json.optional
+        private final UnionAZ contained;
+
+        @B2Json.constructor(params = "contained")
+        private ContainsOptionalUnion(UnionAZ contained) {
+            this.contained = contained;
         }
     }
 


### PR DESCRIPTION
tested with new unit test cases.

i'm not the B2Json expert, so I'll probably wait to merge this until brianb
can review it to see if i got it right and see if there are any cases i missed.