### PR TITLE
Fix bug: builder for B2ListUnfinishedLargeFileRequest didn't copy all…

### DIFF
--- a/core/src/main/java/com/backblaze/b2/client/structures/B2ListUnfinishedLargeFilesRequest.java
+++ b/core/src/main/java/com/backblaze/b2/client/structures/B2ListUnfinishedLargeFilesRequest.java
@@ -87,6 +87,7 @@ public class B2ListUnfinishedLargeFilesRequest {
 
         public Builder(B2ListUnfinishedLargeFilesRequest orig) {
             this.bucketId = orig.bucketId;
+            this.namePrefix = orig.namePrefix;
             this.startFileId = orig.startFileId;
             this.maxFileCount = orig.maxFileCount;
         }

--- a/core/src/test/java/com/backblaze/b2/client/structures/B2ListUnfinishedLargeFilesRequestTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/structures/B2ListUnfinishedLargeFilesRequestTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018, Backblaze, Inc.  All rights reserved.
+ */
+
+package com.backblaze.b2.client.structures;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class B2ListUnfinishedLargeFilesRequestTest {
+
+    @Test
+    public void testBuilderCopies() {
+        final B2ListUnfinishedLargeFilesRequest original =
+                new B2ListUnfinishedLargeFilesRequest(
+                        "bucketId",
+                        "namePrefix",
+                        "startFileId",
+                        123
+                );
+        assertEquals(
+                original,
+                B2ListUnfinishedLargeFilesRequest.builder(original).build()
+        );
+    }
+
+    @Test
+    public void testBuilderSetsAll() {
+        final B2ListUnfinishedLargeFilesRequest original =
+                new B2ListUnfinishedLargeFilesRequest(
+                        "bucketId",
+                        "namePrefix",
+                        "startFileId",
+                        123
+                );
+        assertEquals(
+                original,
+                B2ListUnfinishedLargeFilesRequest
+                        .builder("bucketId")
+                        .setNamePrefix("namePrefix")
+                        .setStartFileId("startFileId")
+                        .setMaxFileCount(123)
+                        .build()
+        );
+    }
+}


### PR DESCRIPTION
… fields.

Testing: gradlew test