### PR TITLE
Eliminate uses of the default charset by B2Json.

### DIFF
--- a/core/src/main/java/com/backblaze/b2/client/B2Sdk.java
+++ b/core/src/main/java/com/backblaze/b2/client/B2Sdk.java
@@ -5,6 +5,7 @@
 package com.backblaze.b2.client;
 
 import com.backblaze.b2.util.B2Preconditions;
+import com.backblaze.b2.util.B2StringUtil;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -17,7 +18,7 @@ public class B2Sdk {
 
     private static String readVersion() {
         try (final InputStream in = B2Sdk.class.getClassLoader().getResourceAsStream("b2-sdk-core/version.txt");
-             final BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
+             final BufferedReader reader = new BufferedReader(new InputStreamReader(in, B2StringUtil.UTF8))) {
             final String version = reader.readLine().trim();
             B2Preconditions.checkState(!version.isEmpty());
             return version;

--- a/core/src/main/java/com/backblaze/b2/client/B2StorageClientWebifierImpl.java
+++ b/core/src/main/java/com/backblaze/b2/client/B2StorageClientWebifierImpl.java
@@ -62,6 +62,7 @@ import com.backblaze.b2.util.B2ByteProgressListener;
 import com.backblaze.b2.util.B2ByteRange;
 import com.backblaze.b2.util.B2InputStreamWithByteProgressListener;
 import com.backblaze.b2.util.B2Preconditions;
+import com.backblaze.b2.util.B2StringUtil;
 
 import java.io.IOException;
 import java.util.Base64;
@@ -150,7 +151,7 @@ public class B2StorageClientWebifierImpl implements B2StorageClientWebifier {
 
     private String makeAuthorizationValue(B2AuthorizeAccountRequest request) {
         final String value = request.getApplicationKeyId() + ":" + request.getApplicationKey();
-        return "Basic " + base64Encoder.encodeToString(value.getBytes());
+        return "Basic " + base64Encoder.encodeToString(B2StringUtil.getUtf8Bytes(value));
     }
 
     @Override

--- a/core/src/main/java/com/backblaze/b2/json/B2Json.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2Json.java
@@ -178,7 +178,7 @@ public class B2Json {
             B2JsonWriter jsonWriter = new B2JsonWriter(out);
             //noinspection unchecked
             handler.serialize(obj, options, jsonWriter);
-            return out.toString();
+            return out.toString(B2StringUtil.UTF8);
         } catch (IOException e) {
             throw new RuntimeException("IO exception writing to string");
         }
@@ -278,7 +278,7 @@ public class B2Json {
             B2JsonWriter jsonWriter = new B2JsonWriter(out);
             //noinspection unchecked
             handler.serialize(list, options, jsonWriter);
-            return out.toString();
+            return out.toString(B2StringUtil.UTF8);
         } catch (IOException e) {
             throw new RuntimeException("IO exception writing to string");
         }

--- a/core/src/test/java/com/backblaze/b2/client/B2ContentDetailsForUploadTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2ContentDetailsForUploadTest.java
@@ -124,7 +124,7 @@ public class B2ContentDetailsForUploadTest extends B2BaseTest {
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         B2IoUtils.copy(inputStream, outputStream);
 
-        final String actualContents = outputStream.toString();
+        final String actualContents = outputStream.toString(B2StringUtil.UTF8);
         assertEquals(expectedContents, actualContents);
     }
 }

--- a/core/src/test/java/com/backblaze/b2/client/B2StorageClientWebifierImplTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2StorageClientWebifierImplTest.java
@@ -225,11 +225,11 @@ public class B2StorageClientWebifierImplTest extends B2BaseTest {
             return b.toString();
         }
 
-        private String copyToString(InputStream inputStream) {
+        private String copyUtf8ToString(InputStream inputStream) {
             try {
                 final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
                 B2IoUtils.copy(inputStream, outputStream);
-                return outputStream.toString();
+                return outputStream.toString(B2StringUtil.UTF8);
             } catch (IOException e) {
                 throw new RuntimeException("unexpected exception: " + e, e);
             }
@@ -249,7 +249,7 @@ public class B2StorageClientWebifierImplTest extends B2BaseTest {
                     "headers:\n" +
                     indent(toString(headersOrNull)) + "\n" +
                     "inputStream:\n" +
-                    indent(copyToString(inputStream)) + "\n" +
+                    indent(copyUtf8ToString(inputStream)) + "\n" +
                     "contentLength:\n" +
                     indent("") + contentLength + "\n" +
                     "responseClass:\n" +

--- a/core/src/test/java/com/backblaze/b2/client/contentHandlers/B2ContentWriterTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/contentHandlers/B2ContentWriterTest.java
@@ -11,6 +11,7 @@ import com.backblaze.b2.client.exceptions.B2Exception;
 import com.backblaze.b2.util.B2BaseTest;
 import com.backblaze.b2.util.B2ByteRange;
 import com.backblaze.b2.util.B2Sha1;
+import com.backblaze.b2.util.B2StringUtil;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -211,7 +212,7 @@ public class B2ContentWriterTest extends B2BaseTest {
 
     @Test
     public void testSha1CheckFailsWhileRereadingFromDestination() throws B2Exception, IOException {
-        writer.addToDestination("ab".getBytes()); // this will mess up the checksum we get later!
+        writer.addToDestination(B2StringUtil.getUtf8Bytes("ab")); // this will mess up the checksum we get later!
 
         thrown.expect(B2Exception.class);
         thrown.expectMessage("sha1 mismatch from destination.  expected " + rightSha1 + ", but got 52386c157cc658dc5794f01e40bf55c752f1ff79");
@@ -220,7 +221,7 @@ public class B2ContentWriterTest extends B2BaseTest {
 
     @Test
     public void testRereadingFromDestinationIsntPerformedWhenToldNotTo() throws B2Exception, IOException {
-        writer.addToDestination("ab".getBytes()); // this will mess up the checksum from the destination
+        writer.addToDestination(B2StringUtil.getUtf8Bytes("ab")); // this will mess up the checksum from the destination
 
         // this writer doesn't double check its work, so it won't notice the mismatch in the destination.
         final Writer lackadaisicalWriter = new Writer(false);

--- a/core/src/test/java/com/backblaze/b2/client/contentSources/B2ByteArrayContentSourceTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/contentSources/B2ByteArrayContentSourceTest.java
@@ -5,6 +5,7 @@
 package com.backblaze.b2.client.contentSources;
 
 import com.backblaze.b2.util.B2BaseTest;
+import com.backblaze.b2.util.B2StringUtil;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
@@ -17,7 +18,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 public class B2ByteArrayContentSourceTest extends B2BaseTest {
-    private static final byte[] sourceBytes = "Hello, World!".getBytes();
+    private static final byte[] sourceBytes = B2StringUtil.getUtf8Bytes("Hello, World!");
     private static final Long SRC_LAST_MOD_MILLIS = 123456L;
 
     @Test

--- a/core/src/test/java/com/backblaze/b2/util/B2InputStreamExcerptTest.java
+++ b/core/src/test/java/com/backblaze/b2/util/B2InputStreamExcerptTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.verify;
 
 public class B2InputStreamExcerptTest extends B2BaseTest {
     private static final String DIGITS_STR = "0123456789";
-    private static final byte[] DIGITS_BYTES = DIGITS_STR.getBytes();
+    private static final byte[] DIGITS_BYTES = B2StringUtil.getUtf8Bytes(DIGITS_STR);
     private static final int EOF = -1;
 
     @Rule
@@ -30,7 +30,7 @@ public class B2InputStreamExcerptTest extends B2BaseTest {
     @After
     public void after() {
         // make sure we didn't corrupt the array during the tests.
-        assertArrayEquals(DIGITS_STR.getBytes(), DIGITS_BYTES);
+        assertArrayEquals(B2StringUtil.getUtf8Bytes(DIGITS_STR), DIGITS_BYTES);
     }
 
     @Test

--- a/core/src/test/java/com/backblaze/b2/util/B2Sha1AppenderInputStreamTest.java
+++ b/core/src/test/java/com/backblaze/b2/util/B2Sha1AppenderInputStreamTest.java
@@ -101,7 +101,7 @@ public class B2Sha1AppenderInputStreamTest extends B2BaseTest {
         assertEquals(-1, withSha1.read());
 
         // does the destination contain the expected contents?
-        final String actual = new String(dest);
+        final String actual = new String(dest, B2StringUtil.UTF8);
         final String expected = CONTENTS + SHA1;
         assertEquals(expected, actual);
     }

--- a/core/src/test/java/com/backblaze/b2/util/B2Utf8UtilTest.java
+++ b/core/src/test/java/com/backblaze/b2/util/B2Utf8UtilTest.java
@@ -59,7 +59,7 @@ public class B2Utf8UtilTest extends B2BaseTest {
     }
 
     private void checkValidCodePoint(String str) throws IOException {
-        final byte[] fromJava = str.getBytes(StandardCharsets.UTF_8);
+        final byte[] fromJava = B2StringUtil.getUtf8Bytes(str);
         final byte[] ourBytes = convert(str);
 
         if (!Arrays.equals(fromJava, ourBytes)) {
@@ -97,7 +97,7 @@ public class B2Utf8UtilTest extends B2BaseTest {
                 final String codePointStr = stringForCodePoint(codePoint);
                 if (codePoint < 32) {
                     final String expected = '"' + String.format("\\u%04x", codePoint) + '"';
-                    checkByteArrays(expected.getBytes(), convertForJsonString(codePointStr));
+                    checkByteArrays(B2StringUtil.getUtf8Bytes(expected), convertForJsonString(codePointStr));
                 } else if (codePoint == '"') {
                     // in json, it should be "\"", so...
                     final byte[] expected = { '"', '\\', '"', '"'};
@@ -132,7 +132,7 @@ public class B2Utf8UtilTest extends B2BaseTest {
 
     private void checkValidCodePointForJsonString(String str) throws IOException {
         final String quotedStr = '"' + str + '"';
-        final byte[] fromJava = quotedStr.getBytes(StandardCharsets.UTF_8);
+        final byte[] fromJava = B2StringUtil.getUtf8Bytes(quotedStr);
         final byte[] ourBytes = convertForJsonString(str);
 
         checkByteArrays(fromJava, ourBytes);


### PR DESCRIPTION
To find them, I set a breakpoint in Charset.defaultCharset() and
ran the unit tests.  That found the cases I already knew about,
plus a bunch of other ones.

Testing: unit tests