### PR TITLE
Add okhttp module for compatibility with Android http stack

### DIFF
--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -1,0 +1,22 @@
+// Copyright 2017, Backblaze Inc. All Rights Reserved.
+// License https://www.backblaze.com/using_b2_code.html
+
+project.ext {
+    pomArtifactId = 'b2-sdk-httpclient'
+    pomName = 'B2 SDK for Java for Apache HttpClient'
+    pomDescription = 'Apache HttpClient support for B2 SDK for Java.'
+}
+
+apply from: '../common.gradle'
+
+// this implementation is built on httpclient, which needs commons-logging.
+dependencies {
+    // we need the core of the project!
+    compile project(':core')
+    
+    // apache http commons (https://hc.apache.org/httpcomponents-client-ga/httpclient/dependency-info.html)
+    compile 'org.apache.httpcomponents:httpclient:4.5.3'
+
+    // apache commons logging  (https://mvnrepository.com/artifact/commons-logging/commons-logging/1.2)
+    implementation group: 'commons-logging', name: 'commons-logging', version: '1.2'
+}

--- a/okhttp/src/main/java/com/backblaze/b2/client/webApiHttpClient/B2StorageHttpClientBuilder.java
+++ b/okhttp/src/main/java/com/backblaze/b2/client/webApiHttpClient/B2StorageHttpClientBuilder.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017, Backblaze Inc. All Rights Reserved.
+ * License https://www.backblaze.com/using_b2_code.html
+ */
+package com.backblaze.b2.client.webApiHttpClient;
+
+import com.backblaze.b2.client.B2AccountAuthorizer;
+import com.backblaze.b2.client.B2AccountAuthorizerSimpleImpl;
+import com.backblaze.b2.client.B2ClientConfig;
+import com.backblaze.b2.client.B2DefaultRetryPolicy;
+import com.backblaze.b2.client.B2RetryPolicy;
+import com.backblaze.b2.client.B2Sdk;
+import com.backblaze.b2.client.B2StorageClient;
+import com.backblaze.b2.client.B2StorageClientImpl;
+import com.backblaze.b2.client.B2StorageClientWebifier;
+import com.backblaze.b2.client.B2StorageClientWebifierImpl;
+import com.backblaze.b2.client.credentialsSources.B2Credentials;
+import com.backblaze.b2.client.credentialsSources.B2CredentialsFromEnvironmentSource;
+import com.backblaze.b2.client.exceptions.B2Exception;
+import com.backblaze.b2.client.webApiClients.B2WebApiClient;
+import com.backblaze.b2.util.B2Preconditions;
+
+import java.util.function.Supplier;
+
+public class B2StorageHttpClientBuilder {
+
+    private static final String DEFAULT_MASTER_URL = "https://api.backblazeb2.com/";
+    private final B2ClientConfig config;
+    private B2WebApiClient webApiClient;
+    private HttpClientFactory httpClientFactory;
+    private Supplier<B2RetryPolicy> retryPolicySupplier;
+
+    @SuppressWarnings("WeakerAccess")
+    public static B2StorageHttpClientBuilder builder(B2ClientConfig config) {
+        return new B2StorageHttpClientBuilder(config);
+    }
+
+    // We don't usually have several builder() methods, but this builder
+    // is used by *everyone*, so i want to make it so that most users don't
+    // need to worry about making an authorizer.
+    @SuppressWarnings("WeakerAccess")
+    public static B2StorageHttpClientBuilder builder(String applicationKeyId, String applicationKey, String userAgent) {
+        final B2AccountAuthorizer accountAuthorizer = B2AccountAuthorizerSimpleImpl
+                .builder(applicationKeyId, applicationKey)
+                .build();
+        final B2ClientConfig config = B2ClientConfig
+                .builder(accountAuthorizer, userAgent)
+                .build();
+        return builder(config);
+    }
+
+    /**
+     * @param userAgent the user agent to use when performing http requests.
+     * @return a storage builder.
+     * @throws B2Exception if there's a problem getting the credentials from the environment.
+     */
+    public static B2StorageHttpClientBuilder builder(String userAgent) throws B2Exception {
+        final B2Credentials credentials = B2CredentialsFromEnvironmentSource.build().getCredentials();
+        return builder(credentials.getApplicationKeyId(), credentials.getApplicationKey(), userAgent);
+    }
+
+    private B2StorageHttpClientBuilder(B2ClientConfig config) {
+        this.config = config;
+    }
+
+    public B2StorageClient build() {
+        final B2WebApiClient webApiClient = (this.webApiClient != null) ?
+                this.webApiClient :
+                B2WebApiHttpClientImpl.builder().setHttpClientFactory(httpClientFactory).build();
+        final B2StorageClientWebifier webifier = new B2StorageClientWebifierImpl(
+                webApiClient,
+                config.getUserAgent() + " " + B2Sdk.getName() + "/" + B2Sdk.getVersion(),
+                (config.getMasterUrl() == null) ? DEFAULT_MASTER_URL : config.getMasterUrl(),
+                config.getTestModeOrNull());
+        final Supplier<B2RetryPolicy> retryPolicySupplier = (this.retryPolicySupplier != null) ?
+                this.retryPolicySupplier :
+                B2DefaultRetryPolicy.supplier();
+        return new B2StorageClientImpl(
+                webifier,
+                config,
+                retryPolicySupplier);
+    }
+
+    public B2StorageHttpClientBuilder setHttpClientFactory(HttpClientFactory httpClientFactory) {
+        B2Preconditions.checkState(webApiClient == null, "httpClientFactory is only used if webApiClient isn't specified, so at most one of them can be non-null!");
+        this.httpClientFactory = httpClientFactory;
+        return this;
+    }
+
+    @SuppressWarnings("unused")
+    public B2StorageHttpClientBuilder setWebApiClient(B2WebApiClient webApiClient) {
+        B2Preconditions.checkState(httpClientFactory == null, "httpClientFactory is only used if webApiClient isn't specified, so at most one of them can be non-null!");
+        this.webApiClient = webApiClient;
+        return this;
+    }
+
+    @SuppressWarnings("unused")
+    public B2StorageHttpClientBuilder setRetryPolicySupplier(Supplier<B2RetryPolicy> retryPolicySupplier) {
+        this.retryPolicySupplier = retryPolicySupplier;
+        return this;
+    }
+}

--- a/okhttp/src/main/java/com/backblaze/b2/client/webApiHttpClient/B2WebApiHttpClientImpl.java
+++ b/okhttp/src/main/java/com/backblaze/b2/client/webApiHttpClient/B2WebApiHttpClientImpl.java
@@ -1,0 +1,363 @@
+/*
+ * Copyright 2017, Backblaze Inc. All Rights Reserved.
+ * License https://www.backblaze.com/using_b2_code.html
+ */
+package com.backblaze.b2.client.webApiHttpClient;
+
+import com.backblaze.b2.client.contentHandlers.B2ContentSink;
+import com.backblaze.b2.client.contentSources.B2Headers;
+import com.backblaze.b2.client.contentSources.B2HeadersImpl;
+import com.backblaze.b2.client.exceptions.B2ConnectFailedException;
+import com.backblaze.b2.client.exceptions.B2ConnectionBrokenException;
+import com.backblaze.b2.client.exceptions.B2Exception;
+import com.backblaze.b2.client.exceptions.B2LocalException;
+import com.backblaze.b2.client.exceptions.B2NetworkException;
+import com.backblaze.b2.client.exceptions.B2NetworkTimeoutException;
+import com.backblaze.b2.client.structures.B2ErrorStructure;
+import com.backblaze.b2.client.webApiClients.B2WebApiClient;
+import com.backblaze.b2.json.B2Json;
+import com.backblaze.b2.json.B2JsonException;
+import com.backblaze.b2.json.B2JsonOptions;
+import com.backblaze.b2.util.B2Preconditions;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpStatus;
+import org.apache.http.NoHttpResponseException;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.conn.ConnectTimeoutException;
+import org.apache.http.conn.ConnectionPoolTimeoutException;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.util.EntityUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.ConnectException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+
+import static com.backblaze.b2.util.B2IoUtils.closeQuietly;
+
+public class B2WebApiHttpClientImpl implements B2WebApiClient {
+    private final static String UTF8 = "UTF-8";
+
+    private final B2Json bzJson = B2Json.get();
+    private final HttpClientFactory clientFactory;
+
+    private B2WebApiHttpClientImpl(HttpClientFactory clientFactory) {
+        this.clientFactory = (clientFactory != null) ?
+                clientFactory :
+                HttpClientFactoryImpl.build();
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public static Builder builder() {
+        return new Builder();
+    }
+
+
+    @Override
+    public <ResponseType> ResponseType postJsonReturnJson(String url,
+                                                          B2Headers headersOrNull,
+                                                          Object request,
+                                                          Class<ResponseType> responseClass) throws B2Exception {
+        final String responseString = postJsonAndReturnString(url, headersOrNull, request);
+        try {
+            return bzJson.fromJson(responseString, responseClass, B2JsonOptions.DEFAULT_AND_ALLOW_EXTRA_FIELDS);
+        } catch (B2JsonException e) {
+            throw new B2LocalException("parsing_failed", "can't convert response from json: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public <ResponseType> ResponseType postDataReturnJson(String url,
+                                                          B2Headers headersOrNull,
+                                                          InputStream inputStream,
+                                                          long contentLength,
+                                                          Class<ResponseType> responseClass) throws B2Exception {
+        try {
+            InputStreamEntity requestEntity = new InputStreamEntity(inputStream, contentLength);
+            String responseJson = postAndReturnString(url, headersOrNull, requestEntity);
+            return B2Json.get().fromJson(responseJson, responseClass, B2JsonOptions.DEFAULT_AND_ALLOW_EXTRA_FIELDS);
+        } catch (B2JsonException e) {
+            throw new B2LocalException("parsing_failed", "can't convert response from json: " + e.getMessage(), e);
+        }
+    }
+
+
+    @Override
+    public void getContent(String url,
+                           B2Headers headersOrNull,
+                           B2ContentSink handler) throws B2Exception {
+
+        HttpGet get = new HttpGet(url);
+        if (headersOrNull != null) {
+            get.setHeaders(makeHeaders(headersOrNull));
+        }
+
+        try (CloseableHttpResponse response = clientFactory.create().execute(get)) {
+            int statusCode = response.getStatusLine().getStatusCode();
+            HttpEntity responseEntity = response.getEntity();
+            if (200 <= statusCode && statusCode < 300) {
+                InputStream content = responseEntity.getContent();
+                handler.readContent(makeHeaders(response.getAllHeaders()), content);
+
+                // The handler reads the entire contents, but may not make the
+                // additional call to read that hits EOF and returns -1.  That
+                // last step is necessary for the HTTP library to reuse the
+                // connection.  So don't remove this call to read(), even if
+                // the logging proves unnecessary.
+                //noinspection ResultOfMethodCallIgnored
+                content.read();
+                //if (content.read() != -1) {
+                //    log.warn("handler did not read full response from " + url);
+                //}
+            } else {
+                String responseText = EntityUtils.toString(responseEntity, UTF8);
+                throw extractExceptionFromErrorResponse(response, responseText);
+            }
+        } catch (IOException e) {
+            throw translateToB2Exception(e, url);
+        }
+    }
+
+    /**
+     * HEADSs to a web service that returns content, and returns the headers.
+     *
+     * @param url the url to head to
+     * @param headersOrNull the headers, if any.
+     * @return the headers of the response.
+     * @throws B2Exception if there's any trouble
+     */
+    @Override
+    public B2Headers head(String url, B2Headers headersOrNull)
+            throws B2Exception {
+
+        CloseableHttpResponse response = null;
+        try {
+            HttpHead head = new HttpHead(url);
+            if (headersOrNull != null) {
+                head.setHeaders(makeHeaders(headersOrNull));
+            }
+
+            response = clientFactory.create().execute(head);
+
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode == HttpStatus.SC_OK) {
+                B2HeadersImpl.Builder builder = B2HeadersImpl.builder();
+                Arrays.stream(response.getAllHeaders()).forEach(header -> builder.set(header.getName(), header.getValue()));
+                return builder.build();
+            } else {
+                throw B2Exception.create(null, statusCode, null, "");
+            }
+        } catch (IOException e) {
+            throw translateToB2Exception(e, url);
+        }
+        finally {
+            closeQuietly(response);
+        }
+    }
+
+    @Override
+    public void close() {
+        clientFactory.close();
+    }
+
+    private B2Headers makeHeaders(Header[] allHeaders) {
+        final B2HeadersImpl.Builder builder = B2HeadersImpl.builder();
+        for (Header header : allHeaders) {
+            builder.set(header.getName(), header.getValue());
+        }
+        return builder.build();
+    }
+
+    private String postJsonAndReturnString(String url,
+                                           B2Headers headersOrNull,
+                                           Object request) throws B2Exception {
+        ByteArrayEntity requestEntity = parseToByteArrayEntityUsingBzJson(request);
+        return postAndReturnString(url, headersOrNull, requestEntity);
+    }
+
+    /**
+     * POSTs to a web service that returns content, and returns the content
+     * as a single string.
+     *
+     * @param url the url to post to
+     * @param headersOrNull the headers, if any.
+     * @param requestEntity the entity to post.
+     * @return the body of the response.
+     * @throws B2Exception if there's any trouble
+     */
+    private String postAndReturnString(String url, B2Headers headersOrNull, HttpEntity requestEntity)
+            throws B2Exception {
+
+        CloseableHttpResponse response = null;
+        try {
+            HttpPost post = new HttpPost(url);
+            if (headersOrNull != null) {
+                post.setHeaders(makeHeaders(headersOrNull));
+            }
+            if (requestEntity != null) {
+                post.setEntity(requestEntity);
+            }
+
+            response = clientFactory.create().execute(post);
+
+            HttpEntity responseEntity = response.getEntity();
+            String responseText = EntityUtils.toString(responseEntity, "UTF-8");
+
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode == HttpStatus.SC_OK) {
+                return responseText;
+            } else {
+                throw extractExceptionFromErrorResponse(response, responseText);
+            }
+        } catch (IOException e) {
+            throw translateToB2Exception(e, url);
+        }
+        finally {
+            closeQuietly(response);
+        }
+    }
+
+    private B2Exception translateToB2Exception(IOException e, String url) {
+        if (e instanceof ConnectException) {
+            // java.net base class for HttpHostConnectException.
+            return new B2ConnectFailedException("connect_failed", null, "failed to connect for " + url, e);
+        }
+        if (e instanceof UnknownHostException) {
+            return new B2ConnectFailedException("unknown_host", null, "unknown host for " + url, e);
+        }
+        if (e instanceof ConnectionPoolTimeoutException) {
+            // from HTTP Components
+            return new B2ConnectFailedException("connect_timed_out", null, "connect timed out for " + url, e);
+        }
+        if (e instanceof ConnectTimeoutException) {
+            // from HTTP Components
+            return new B2ConnectFailedException("connection_pool_timed_out", null, "connection pool timed out for " + url, e);
+        }
+        if (e instanceof SocketTimeoutException) {
+            return new B2NetworkTimeoutException("socket_timeout", null, "socket timed out talking to " + url, e);
+        }
+        if (e instanceof SocketException) {
+            return new B2NetworkException("socket_exception", null, "socket exception talking to " + url, e);
+        }
+        if (e instanceof NoHttpResponseException) {
+            return new B2ConnectionBrokenException("no_http_response", null, "didn't get an http response from " + url, e);
+        }
+
+        return new B2NetworkException("io_exception", null, e + " talking to " + url, e);
+    }
+
+    private B2Exception extractExceptionFromErrorResponse(CloseableHttpResponse response,
+                                                          String responseText) {
+        final int statusCode = response.getStatusLine().getStatusCode();
+
+        // Try B2 error structure
+        try {
+            B2ErrorStructure err = B2Json.get().fromJson(responseText, B2ErrorStructure.class);
+            return B2Exception.create(err.code, err.status, getRetryAfterSecondsOrNull(response), err.message);
+        }
+        catch (Throwable t) {
+            // we can't parse the response as a B2 JSON error structure.
+            // so use the default.
+            return new B2Exception("unknown", statusCode, getRetryAfterSecondsOrNull(response), responseText);
+        }
+    }
+
+    /**
+     * If there's a Retry-After header and it has a delay-seconds formatted value,
+     * this returns it.  (to be clear, if there's an HTTP-date value, we ignore it
+     * and keep looking for one with delay-seconds format.)
+     *
+     * @param response the http response.
+     * @return the delay-seconds from a Retry-After header, if any.  otherwise, null.
+     */
+    private Integer getRetryAfterSecondsOrNull(CloseableHttpResponse response) {
+        // https://tools.ietf.org/html/rfc7231#section-7.1.3
+        for (Header header : response.getHeaders(B2Headers.RETRY_AFTER)) {
+            try {
+                return Integer.parseInt(header.getValue(), 10);
+            } catch (IllegalArgumentException e) {
+                // continue.
+            }
+        }
+
+        return null;
+    }
+
+    private Header[] makeHeaders(B2Headers headersOrNull) {
+        if (headersOrNull == null) {
+            return null;
+        }
+        final int headerCount = headersOrNull.getNames().size();
+        final Header[] vHeaders = new Header[headerCount];
+
+        int iHeader = 0;
+        for (String name : headersOrNull.getNames()) {
+            vHeaders[iHeader] = new BasicHeader(name, headersOrNull.getValueOrNull(name));
+            iHeader++;
+        }
+
+        return vHeaders;
+    }
+
+
+    /**
+     * Parse Json using our beloved B2Json
+     *
+     * @param request the object to be json'ified.
+     * @return a new ByteArrayEntity with the json representation of request in it.
+     */
+    private static ByteArrayEntity parseToByteArrayEntityUsingBzJson(Object request) throws B2Exception {
+        B2Preconditions.checkArgument(request != null);
+
+        try {
+            B2Json bzJson = B2Json.get();
+            String requestJson = bzJson.toJson(request);
+            byte[] requestBytes = getUtf8Bytes(requestJson);
+            return new ByteArrayEntity(requestBytes);
+        } catch (B2JsonException e) {
+            //log.warn("Unable to serialize " + request.getClass() + " using B2Json, was passed in request for " + url, ex);
+            throw new B2LocalException("parsing_failed", "B2Json.toJson(" + request.getClass() + ") failed: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Returns the UTF-8 representation of a string.
+     */
+    private static byte [] getUtf8Bytes(String str) throws B2Exception {
+        try {
+            return str.getBytes(UTF8);
+        } catch (UnsupportedEncodingException e) {
+            // this is very, very bad and it's not gonna get better by itself.
+            throw new RuntimeException("No UTF-8 charset", e);
+        }
+    }
+
+    /**
+     * This Builder creates HttpClientFactoryImpls.
+     * If the httpClientFactory isn't set, a new instance
+     * of the default implementation will be used.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static class Builder {
+        private HttpClientFactory httpClientFactory;
+
+        public Builder setHttpClientFactory(HttpClientFactory httpClientFactory) {
+            this.httpClientFactory = httpClientFactory;
+            return this;
+        }
+
+        public B2WebApiHttpClientImpl build() {
+            return new B2WebApiHttpClientImpl(httpClientFactory);
+        }
+    }
+}

--- a/okhttp/src/main/java/com/backblaze/b2/client/webApiHttpClient/HttpClientFactory.java
+++ b/okhttp/src/main/java/com/backblaze/b2/client/webApiHttpClient/HttpClientFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017, Backblaze Inc. All Rights Reserved.
+ * License https://www.backblaze.com/using_b2_code.html
+ */
+package com.backblaze.b2.client.webApiHttpClient;
+
+import com.backblaze.b2.client.exceptions.B2Exception;
+import org.apache.http.impl.client.CloseableHttpClient;
+
+public interface HttpClientFactory extends AutoCloseable {
+
+    /**
+     * This returns a CloseableHttpClient (instead of an HttpClient) because
+     * the SDK needs to be able to close the responses to allow connections
+     * to be reused.
+     *
+     * Note that even though this returns a CloseableHttpClient,
+     * the SDK will *not* call close() on it, because doing so
+     * would close the client's HttpClientConnectionManager.
+     *
+     * @return a new httpClient for use by the SDK.
+     *         this will be called often.
+     * @throws B2Exception if there's any trouble creating the client.
+     */
+    CloseableHttpClient create() throws B2Exception;
+
+    /**
+     * Called to release resources, such as an HttpClientConnectionManager.
+     */
+    @Override
+    void close();
+}

--- a/okhttp/src/main/java/com/backblaze/b2/client/webApiHttpClient/HttpClientFactoryImpl.java
+++ b/okhttp/src/main/java/com/backblaze/b2/client/webApiHttpClient/HttpClientFactoryImpl.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2017, Backblaze Inc. All Rights Reserved.
+ * License https://www.backblaze.com/using_b2_code.html
+ */
+package com.backblaze.b2.client.webApiHttpClient;
+
+import com.backblaze.b2.client.exceptions.B2Exception;
+import com.backblaze.b2.util.B2Preconditions;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.ssl.SSLContexts;
+import org.apache.http.util.VersionInfo;
+
+import javax.net.ssl.SSLContext;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This is the default HttpClientFactory implementation.
+ *
+ * Created HttpClients always support 'https' because that's what the
+ * production B2 servers require.  By default, the created HttpClients
+ * do not support 'http' to ensure we don't send data over http by accident.
+ *
+ * If you have a non-https implementation of B2 that you test against,
+ * you *may* choose to enable 'http' support when creating the factory.
+ * We really do *not* recommend that in production.
+ */
+public class HttpClientFactoryImpl implements HttpClientFactory {
+    private final HttpClientConnectionManager connectionManager;
+    private final RequestConfig requestConfig;
+    private final IdleConnectionMonitorThread connectionJanitor;
+
+    /**
+     * This is the user-agent we should use on Apache HttpClient instances.
+     * If we do not set it, HttpClientBuilder will compute this every time
+     * it creates an HttpClient (and we do that A LOT).  That wouldn't
+     * be so bad, except that internally it gets its own version by opening
+     * a resource stream which involves opening a jar and using a ZipFile
+     * instance, etc, so it's a non-obvious amount of work.  (at least as
+     * of httpcomponents-client-4.5.2).  So, we do the work once and
+     * manually set the userAgent from the resulting constant.
+     */
+    private static final String APACHE_HTTP_CLIENT_USER_AGENT = VersionInfo.getUserAgent("Apache-HttpClient",
+            "org.apache.http.client", HttpClientBuilder.class);
+
+
+    private HttpClientFactoryImpl(HttpClientConnectionManager connectionManager,
+                          RequestConfig requestConfig) {
+        this.connectionManager = connectionManager;
+        this.requestConfig = requestConfig;
+        connectionJanitor = new IdleConnectionMonitorThread(connectionManager);
+        connectionJanitor.start();
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public static HttpClientFactoryImpl build() {
+        return builder().build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public CloseableHttpClient create() throws B2Exception {
+        return HttpClients.custom()
+                .setUserAgent(APACHE_HTTP_CLIENT_USER_AGENT)
+                .setConnectionManager(connectionManager)
+                .setDefaultRequestConfig(requestConfig)
+                .build();
+    }
+
+    @Override
+    public void close() {
+        connectionManager.shutdown();
+        connectionJanitor.shutdown();
+        try {
+            connectionJanitor.join();
+        } catch (InterruptedException e) {
+            // restore the interrupt because we're not acting on it here.
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * The factory we're building will have close() called on it and when it
+     * does, it will close its connection manager.  Since we don't want to
+     * close a connection manager out from under another factory, each Builder
+     * is only allowed to execute build() once.
+     */
+    public static class Builder {
+        private static final int DEFAULT_CONNECTION_REQUEST_TIMEOUT_SECONDS = 5;
+        private static final int DEFAULT_CONNECT_TIMEOUT_SECONDS = 5;
+        private static final int DEFAULT_SOCKET_TIMEOUT_SECONDS = 20;
+
+        private static final int DEFAULT_MAX_TOTAL_CONNECTIONS_IN_POOL = 100;
+        private static final int DEFAULT_MAX_CONNECTIONS_PER_ROUTE = 100;
+
+        private boolean builtOneAlready;
+
+        // should the clients support 'http'?  (they always support 'https'.)
+        // this is off by default, and that's a good way to leave it.
+        // http is only supported for use with some test environments.
+        private boolean supportInsecureHttp;
+
+        // for RequestConfig
+        private int connectionRequestTimeoutSeconds = DEFAULT_CONNECTION_REQUEST_TIMEOUT_SECONDS;
+        private int connectTimeoutSeconds = DEFAULT_CONNECT_TIMEOUT_SECONDS;
+        private int socketTimeoutSeconds = DEFAULT_SOCKET_TIMEOUT_SECONDS;
+
+        // for connection pool
+        private int maxTotalConnectionsInPool = DEFAULT_MAX_TOTAL_CONNECTIONS_IN_POOL;
+        private int maxConnectionsPerRoute = DEFAULT_MAX_CONNECTIONS_PER_ROUTE;
+
+        public Builder setSupportInsecureHttp(boolean supportInsecureHttp) {
+            this.supportInsecureHttp = supportInsecureHttp;
+            return this;
+        }
+
+        public Builder setConnectionRequestTimeoutSeconds(int connectionRequestTimeoutSeconds) {
+            this.connectionRequestTimeoutSeconds = connectionRequestTimeoutSeconds;
+            return this;
+        }
+
+        public Builder setConnectTimeoutSeconds(int connectTimeoutSeconds) {
+            this.connectTimeoutSeconds = connectTimeoutSeconds;
+            return this;
+        }
+
+        public Builder setSocketTimeoutSeconds(int socketTimeoutSeconds) {
+            this.socketTimeoutSeconds = socketTimeoutSeconds;
+            return this;
+        }
+
+        public Builder setMaxTotalConnectionsInPool(int maxTotalConnectionsInPool) {
+            this.maxTotalConnectionsInPool = maxTotalConnectionsInPool;
+            return this;
+        }
+
+        public Builder setMaxConnectionsPerRoute(int maxConnectionsPerRoute) {
+            this.maxConnectionsPerRoute = maxConnectionsPerRoute;
+            return this;
+        }
+
+
+        public HttpClientFactoryImpl build() {
+            B2Preconditions.checkState(!builtOneAlready, "called build() more than once?!");
+            builtOneAlready = true;
+
+            return new HttpClientFactoryImpl(
+                    createConnectionManager(),
+                    createRequestConfig());
+        }
+
+        private RequestConfig createRequestConfig() {
+            return RequestConfig.custom()
+                    .setConnectionRequestTimeout(connectionRequestTimeoutSeconds * 1000) // time waiting for cxn from pool
+                    .setConnectTimeout(connectTimeoutSeconds * 1000) // time waiting for remote server to connect
+                    .setSocketTimeout(socketTimeoutSeconds * 1000) // time waiting for answer after connecting
+                    .build();
+
+        }
+
+        private HttpClientConnectionManager createConnectionManager() {
+            // For SSL/TLS,
+            //   HttpClient says it uses Java Secure Socket Extension:
+            //     https://hc.apache.org/httpcomponents-client-ga/tutorial/html/connmgmt.html
+            //   java 8 defaults to TLS/1.2.
+            //     https://blogs.oracle.com/java-platform-group/jdk-8-will-use-tls-12-as-default
+            //   for hostname verification,
+            //     HttpClient's DefaultHostnameVerifier is fine and allows wildcard names.
+            //     i've seen some code use ALLOW_ALL_HOSTNAME_VERIFIER, but that's deprecated and bad.
+            //
+            // we are NOT using the default registry because the default supports http
+            // and we usually don't want to suport http.
+            //
+            // This code is based on https://hc.apache.org/httpcomponents-client-ga/tutorial/html/connmgmt.html
+
+            RegistryBuilder<ConnectionSocketFactory> registryBuilder = RegistryBuilder.create();
+
+            // we *always* support https, since that's what the official b2 servers require.
+            {
+                SSLContext sslcontext = SSLContexts.createDefault();
+                ConnectionSocketFactory sslFactory = new SSLConnectionSocketFactory(sslcontext);
+                registryBuilder.register("https", sslFactory);
+            }
+
+            if (supportInsecureHttp) {
+                ConnectionSocketFactory plainFactory = new PlainConnectionSocketFactory();
+                registryBuilder.register("http", plainFactory);
+            }
+
+            final Registry<ConnectionSocketFactory> registry = registryBuilder.build();
+
+            final PoolingHttpClientConnectionManager mgr = new PoolingHttpClientConnectionManager(registry);
+            mgr.setMaxTotal(maxTotalConnectionsInPool);
+            mgr.setDefaultMaxPerRoute(maxConnectionsPerRoute);
+            return mgr;
+        }
+    }
+
+    // from https://hc.apache.org/httpcomponents-client-ga/tutorial/html/connmgmt.html
+    private static class IdleConnectionMonitorThread extends Thread {
+
+        private final HttpClientConnectionManager connMgr;
+        private volatile boolean shutdown;
+
+        IdleConnectionMonitorThread(HttpClientConnectionManager connMgr) {
+            super();
+            this.connMgr = connMgr;
+        }
+
+        @Override
+        public void run() {
+            try {
+                while (!shutdown) {
+                    synchronized (this) {
+                        wait(5000);
+                        // Close expired connections
+                        connMgr.closeExpiredConnections();
+                        // Optionally, close connections
+                        // that have been idle longer than 30 sec
+                        connMgr.closeIdleConnections(30, TimeUnit.SECONDS);
+                    }
+                }
+            } catch (InterruptedException ex) {
+                // terminate
+            }
+        }
+
+        public void shutdown() {
+            shutdown = true;
+            synchronized (this) {
+                notifyAll();
+            }
+        }
+
+    }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,4 +3,5 @@
 
 include 'core'
 include 'httpclient'
+include 'okhttp'
 include 'samples'


### PR DESCRIPTION
OkHttp is pure Java, but is nonetheless the http stack currently in use on Android. The intent here is for Android app developers to be able to use the B2 SDK by adding core and okhttp maven artifacts to their build scripts. In addition, non-Android Java developers may find the more modern OkHttp architecture more to their liking than Apache.

Not in this pull request is the Android B2 quickstart sample application. This should be a separate Github repo IMO, as devs will not need to build the B2 SDK, just use its artifacts. 