### PR TITLE
Adding the sensitive annotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ core/build/
 httpclient/build/
 samples/build/
 b2-sdk-java.iml
+out/
+core/out/

--- a/core/src/main/java/com/backblaze/b2/json/B2Json.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2Json.java
@@ -518,6 +518,14 @@ public class B2Json {
     }
 
     /**
+     * Annotation that says this is a sensitive field and should be redacted when outputting
+     * for logging
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    public @interface sensitive {}
+
+    /**
      * Constructor annotation saying that this is the constructor B2Json
      * should use.  This constructor must take ALL of the serializable
      * fields as parameters.

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonOptions.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonOptions.java
@@ -43,11 +43,22 @@ public class B2JsonOptions {
     private final int version;
 
     /**
+     * Whether to redact sensitive fields
+     *
+     * When set, fields marked as @B2Json.sensitive will be redacted from the serialized
+     * JSON and replaced with the string value "***REDACTED***"
+     * The output will be valid Json but the structure/types will not conform to the expected
+     * output. Use for logging situations where round-tripping the JSON is not required
+     */
+    private final boolean redactSensitive;
+
+    /**
      * Initialize a new B2JsonOptions.
      */
-    private B2JsonOptions(ExtraFieldOption extraFieldOption, int version) {
+    private B2JsonOptions(ExtraFieldOption extraFieldOption, int version, boolean redactSensitive) {
         this.extraFieldOption = extraFieldOption;
         this.version = version;
+        this.redactSensitive = redactSensitive;
     }
 
     /**
@@ -65,6 +76,13 @@ public class B2JsonOptions {
     }
 
     /**
+     * Redact sensitive fields from output
+     */
+    public boolean getRedactSensitive() {
+        return redactSensitive;
+    }
+
+    /**
      * Returns a new builder for B2JsonOptions.
      */
     public static Builder builder() {
@@ -78,9 +96,15 @@ public class B2JsonOptions {
 
         private ExtraFieldOption extraFieldOption = ExtraFieldOption.ERROR;
         private int version = 1;
+        private boolean redactSensitive = false;
 
         public Builder setExtraFieldOption(ExtraFieldOption extraFieldOption) {
             this.extraFieldOption = extraFieldOption;
+            return this;
+        }
+
+        public Builder setRedactSensitive(boolean redactSensitive) {
+            this.redactSensitive = redactSensitive;
             return this;
         }
 
@@ -90,7 +114,7 @@ public class B2JsonOptions {
         }
 
         public B2JsonOptions build() {
-            return new B2JsonOptions(extraFieldOption, version);
+            return new B2JsonOptions(extraFieldOption, version, redactSensitive);
         }
     }
 }

--- a/core/src/main/java/com/backblaze/b2/json/FieldInfo.java
+++ b/core/src/main/java/com/backblaze/b2/json/FieldInfo.java
@@ -25,18 +25,21 @@ public final class FieldInfo implements Comparable<FieldInfo> {
     public final VersionRange versionRange;
     public int constructorArgIndex;
     public long bit;
+    public final boolean isSensitive;
 
     /*package*/ FieldInfo(
             Field field, B2JsonTypeHandler<?> handler,
             FieldRequirement requirement,
             Object defaultValueOrNull,
-            VersionRange versionRange
+            VersionRange versionRange,
+            boolean isSensitive
     ) {
         this.field = field;
         this.handler =  handler;
         this.requirement = requirement;
         this.defaultValueOrNull = defaultValueOrNull;
         this.versionRange = versionRange;
+        this.isSensitive = isSensitive;
 
         this.field.setAccessible(true);
     }
@@ -47,6 +50,10 @@ public final class FieldInfo implements Comparable<FieldInfo> {
 
     public B2JsonTypeHandler getHandler() {
         return handler;
+    }
+
+    public boolean getIsSensitive() {
+        return isSensitive;
     }
 
     public int compareTo(@SuppressWarnings("NullableProblems") FieldInfo o) {

--- a/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
+++ b/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
@@ -1993,6 +1993,36 @@ public class B2JsonTest extends B2BaseTest {
         B2Json.toJsonOrThrowRuntime(obj);
     }
 
+    private static class SecureContainer {
+        @B2Json.required
+        @B2Json.sensitive
+        private final String sensitiveString;
+
+        @B2Json.required
+        private final String insensitiveString;
+
+        @B2Json.constructor(params = "sensitiveString,insensitiveString")
+        public SecureContainer(String secureString, String insecureString) {
+            this.sensitiveString = secureString;
+            this.insensitiveString = insecureString;
+        }
+    }
+
+    @Test
+    public void testSensitiveRedactedWhenOptionSet() {
+        final B2JsonOptions options = B2JsonOptions.builder().setRedactSensitive(true).build();
+        final SecureContainer secureContainer = new SecureContainer("foo", "bar");
+        assertEquals("{\n  \"insensitiveString\": \"bar\",\n  \"sensitiveString\": \"***REDACTED***\"\n}",
+                B2Json.toJsonOrThrowRuntime(secureContainer, options));
+    }
+
+    @Test
+    public void testSensitiveWrittenWhenOptionNotSet() {
+        final B2JsonOptions options = B2JsonOptions.builder().setRedactSensitive(false).build();
+        final SecureContainer secureContainer = new SecureContainer("foo", "bar");
+        assertEquals("{\n  \"insensitiveString\": \"bar\",\n  \"sensitiveString\": \"foo\"\n}",
+                B2Json.toJsonOrThrowRuntime(secureContainer, options));
+    }
 
     /**
      * Because of serialization, the object returned from B2Json will never be the same object as an


### PR DESCRIPTION
Adding @B2Json.sensitive annotation to fields to allow them to be redacted when outputting Json with the setRedactSensitive option on. The output is still valid JSON but no longer will conform to the structure specified, so this cannot be used to round-trip the JSON, however is useful when outputting structures to log files where certain information should not be exposed.