### PR TITLE
uploads: add optional B2ContentSource.createContentSourceWithRangeOrNull()

### DIFF
--- a/core/src/main/java/com/backblaze/b2/client/contentSources/B2ContentSource.java
+++ b/core/src/main/java/com/backblaze/b2/client/contentSources/B2ContentSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, Backblaze Inc. All Rights Reserved.
+ * Copyright 2019, Backblaze Inc. All Rights Reserved.
  * License https://www.backblaze.com/using_b2_code.html
  */
 
@@ -58,6 +58,25 @@ public interface B2ContentSource {
      */
     InputStream createInputStream() throws IOException;
 
-    // XXX: is there a *range* version of createInputStream() to help with
-    //      large files?
+    /**
+     * If possible, this returns a NEW input stream for just the specified range of the
+     * content.  If it's not possible (or just not implemented), this returns null.
+     *
+     * The large file uploading mechanism uses this call to get a stream for each
+     * part that will be uploaded separately.  If this returns null, the large file
+     * uploader will use createInputStream() and read and discard the initial
+     * part of the stream to get to the part it needs.
+     *
+     * This method is optional.  However, if your content source will be used
+     * for large file uploads, please implement it to make your uploads more
+     * efficient.
+     *
+     * NOTE: this may be called multiple times as uploads are retried, etc.
+     *       The overall content is expected to be identical each time this is called.
+     * @return a new inputStream containing the specified range of the overall contents.
+     * @throws IOException if there's trouble
+     */
+    default B2ContentSource createContentSourceWithRangeOrNull(long start, long length) throws IOException {
+        return null;
+    }
 }

--- a/core/src/test/java/com/backblaze/b2/client/B2StorageClientImplTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2StorageClientImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, Backblaze Inc. All Rights Reserved.
+ * Copyright 2019, Backblaze Inc. All Rights Reserved.
  * License https://www.backblaze.com/using_b2_code.html
  */
 package com.backblaze.b2.client;
@@ -88,6 +88,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -834,6 +835,7 @@ public class B2StorageClientImplTest extends B2BaseTest {
 
         verify(contentSource, times(1)).getContentLength();
         verify(contentSource, times(2)).getSha1OrNull(); // once above while making the startLargeRequest for the mock & once for real
+        verify(contentSource, times(2)).createContentSourceWithRangeOrNull(anyLong(), anyLong()); // once above while making the startLargeRequest for the mock & once for real
         verifyNoMoreInteractions(contentSource); // the webifier is a mock, so it doesn't do normal things
 
 
@@ -918,6 +920,7 @@ public class B2StorageClientImplTest extends B2BaseTest {
 
         verify(contentSource, times(1)).getContentLength();
         verify(contentSource, times(1)).getSha1OrNull();
+        verify(contentSource, times(1)).createContentSourceWithRangeOrNull(anyLong(), anyLong());
         verifyNoMoreInteractions(contentSource); // the webifier is a mock, so it doesn't do normal things
 
         // we should be using the existing largeFile, not starting a new one.

--- a/samples/src/main/java/com/backblaze/b2/sample/UploadLargeFileFromUrl.java
+++ b/samples/src/main/java/com/backblaze/b2/sample/UploadLargeFileFromUrl.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2019, Backblaze Inc. All Rights Reserved.
+ * License https://www.backblaze.com/using_b2_code.html
+ */
+package com.backblaze.b2.sample;
+
+import com.backblaze.b2.client.B2ClientConfig;
+import com.backblaze.b2.client.B2Sdk;
+import com.backblaze.b2.client.B2StorageClient;
+import com.backblaze.b2.client.contentSources.B2ContentSource;
+import com.backblaze.b2.client.contentSources.B2ContentTypes;
+import com.backblaze.b2.client.exceptions.B2Exception;
+import com.backblaze.b2.client.structures.B2Bucket;
+import com.backblaze.b2.client.structures.B2FileVersion;
+import com.backblaze.b2.client.structures.B2UploadFileRequest;
+import com.backblaze.b2.client.structures.B2UploadListener;
+import com.backblaze.b2.client.webApiHttpClient.B2StorageHttpClientBuilder;
+import com.backblaze.b2.util.B2ExecutorUtils;
+
+import java.io.PrintWriter;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static com.backblaze.b2.util.B2ExecutorUtils.createThreadFactory;
+
+/**
+ * This program uploads a large file using the UrlContentSource to
+ * get the contents from a URL.
+ *
+ * Unlike other sample programs, it requires a lot of arguments,
+ * so that it can work on non-trivial data.
+ *
+ * Also note that, unlike other sample programs, you must provide
+ * applicationKey and applicationKeyId on the command line. This lets
+ * us show how you can use B2ClientConfig.builder() to provide credentials
+ * instead of having to put them in environment variables.
+ */
+public class UploadLargeFileFromUrl {
+
+    private static final String USER_AGENT = "UploadLargeFileFromUrl";
+
+    public static void main(String[] args) throws B2Exception {
+        if (args.length != 6 && args.length != 7) {
+            System.err.println("usage:");
+            System.err.println("  java -classpath blahBlah " + UploadLargeFileFromUrl.class.getCanonicalName() +
+                    " applicationKeyId applicationKey bucketName fileNameInB2 url contentLen [sha1OrNull]");
+            System.exit(1);
+        }
+        final String appKeyId = args[0];
+        final String appKey = args[1];
+        final String bucketName = args[2];
+        final String fileNameInB2 = args[3];
+        final String url = args[4];
+        final long contentLen = Long.parseLong(args[5]);
+        final String sha1OrNull = (args.length >= 7) ? args[6] : null;
+
+        final PrintWriter writer = new PrintWriter(System.out, true);
+        final ExecutorService executor = Executors.newFixedThreadPool(10, createThreadFactory("sample-executor-%02d"));
+
+        final B2ClientConfig config = B2ClientConfig.builder(appKeyId, appKey, USER_AGENT).build();
+        try (final B2StorageClient client = B2StorageHttpClientBuilder.builder(config).build()) {
+            mainGuts(writer, client, executor, bucketName, fileNameInB2, url, contentLen, sha1OrNull);
+        } finally {
+            B2ExecutorUtils.shutdownAndAwaitTermination(executor, 10, 10);
+        }
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private static void mainGuts(PrintWriter writer,
+                                 B2StorageClient client,
+                                 ExecutorService executor,
+                                 String bucketName,
+                                 String fileNameInB2,
+                                 String url,
+                                 long contentLen,
+                                 String sha1OrNull) throws B2Exception {
+        writer.println("Running with " + B2Sdk.getName() + " version " + B2Sdk.getVersion());
+
+        B2Bucket bucket = client.getBucketOrNullByName(bucketName);
+        if (bucket == null) {
+            System.out.println("bucket " + bucketName + " doesn't exist");
+            System.exit(1);
+        }
+
+        final B2UploadListener uploadListener = (progress) -> {
+            final double percent = (100. * (progress.getBytesSoFar() / (double) progress.getLength()));
+            writer.println(String.format("  progress(%3.2f, %s)", percent, progress.toString()));
+        };
+
+
+        final B2FileVersion file;
+        {
+            B2ContentSource source = new UrlContentSource.Builder(url, contentLen).setSha1OrNull(sha1OrNull).build();
+
+            B2UploadFileRequest request = B2UploadFileRequest
+                    .builder(bucket.getBucketId(), fileNameInB2, B2ContentTypes.B2_AUTO, source)
+                    .setListener(uploadListener)
+                    .build();
+            file = client.uploadLargeFile(request, executor);
+            writer.println("uploaded " + file);
+        }
+    }
+
+}

--- a/samples/src/main/java/com/backblaze/b2/sample/UrlContentSource.java
+++ b/samples/src/main/java/com/backblaze/b2/sample/UrlContentSource.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2019, Backblaze Inc. All Rights Reserved.
+ * License https://www.backblaze.com/using_b2_code.html
+ */
+package com.backblaze.b2.sample;
+
+import com.backblaze.b2.client.contentSources.B2ContentSource;
+import com.backblaze.b2.util.B2ByteRange;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+/**
+ * UrlContentSource is a B2ContentSource that uses HttpURLConnection
+ * to fetch its input from a url.  It is smart enough to use a Range
+ * header when createContentSourceWithRangeOrNull() is called.
+ *
+ * The 'contentLen' is the length of the range that should be returned.
+ * The 'start' index is the offset of the first byte within a stream.
+ */
+class UrlContentSource implements B2ContentSource {
+    private final String urlString;
+    private final long contentLen;
+    private final String sha1OrNull;
+    private final long start;
+
+    private UrlContentSource(String urlString,
+                             long contentLen,
+                             String sha1OrNull,
+                             long start) {
+        this.urlString = urlString;
+        this.contentLen = contentLen;
+        this.sha1OrNull = sha1OrNull;
+        this.start = start;
+    }
+
+    @Override
+    public long getContentLength() {
+        return contentLen;
+    }
+
+    @Override
+    public String getSha1OrNull() {
+        return sha1OrNull;
+    }
+
+    @Override
+    public Long getSrcLastModifiedMillisOrNull() {
+        return null;
+    }
+
+    @Override
+    public InputStream createInputStream() throws IOException {
+        if (contentLen == 0) {
+            // use a simple empty stream.  no need to talk to the server.
+            return new ByteArrayInputStream(new byte[0]);
+        }
+
+        // ok.  there are enough bytes that we need to fetch from the server
+        //      and there are enough that we can make a non-empty range.
+        B2ByteRange range = B2ByteRange.between(start, start+contentLen-1);
+        //System.err.println("createInputStream() for " + range + " from " + urlString);
+
+        final URL url = new URL(urlString);
+        final HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
+        urlConnection.setRequestProperty("Range", range.toString());
+        urlConnection.connect();
+
+        return urlConnection.getInputStream();
+    }
+
+    @Override
+    public B2ContentSource createContentSourceWithRangeOrNull(long start, long length) throws IOException {
+        if (this.start != 0) {
+            // we're already a range.  we shouldn't be called again.
+            throw new IllegalStateException("why is something trying to make a range of a range?");
+        }
+        if (start < 0 || length < 0 || (start+length) > contentLen) {
+            throw new IllegalArgumentException("bad range");
+        }
+        // note that we don't know the sha1 for a range of the content, so we don't provide it.
+        return new Builder(urlString, length).setStart(start).build();
+    }
+
+    public static class Builder {
+        private final String urlString;
+        private final long contentLen;
+        private String sha1OrNull;
+        private long start;
+
+        Builder(String urlString, long contentLen) {
+            this.urlString = urlString;
+            this.contentLen = contentLen;
+        }
+
+        Builder setSha1OrNull(String sha1OrNull) {
+            this.sha1OrNull = sha1OrNull;
+            return this;
+        }
+
+        Builder setStart(long start) {
+            this.start = start;
+            return this;
+        }
+
+        UrlContentSource build() {
+            return new UrlContentSource(urlString, contentLen, sha1OrNull, start);
+        }
+    }
+}


### PR DESCRIPTION

This change teaches B2LargeFileUploader to ask B2ContentSource for
a B2ContentSource for a range of its content.  If the source returns
null (the default), we use the same B2PartOfContentSource to
"manually" excerpt, as we've always done.  The new way makes it more
reasonable to use a remote URL as the content source by making it possible
to do a range request on that URL instead of reading and discarding the
start of the URL multiple times.

testing:
  * some additions to some unit tests.
    i'm open to proposals for additional tests.
  * exercised with the new UploadLargeFileFromUrl sample.