### PR TITLE
add B2StorageClientFactory: a way to create a B2StorageClient without…

### DIFF
--- a/core/src/main/java/com/backblaze/b2/client/B2StorageClientFactory.java
+++ b/core/src/main/java/com/backblaze/b2/client/B2StorageClientFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019, Backblaze Inc. All Rights Reserved.
+ * License https://www.backblaze.com/using_b2_code.html
+ */
+package com.backblaze.b2.client;
+
+import com.backblaze.b2.client.credentialsSources.B2Credentials;
+import com.backblaze.b2.client.credentialsSources.B2CredentialsFromEnvironmentSource;
+
+/**
+ * Implementations of B2StorageClientFactory can create a B2StorageClient from a B2ClientConfig.
+ * There are a couple of convenience methods for constructing B2ClientConfigs.
+ *
+ * THREAD-SAFE.
+ */
+public interface B2StorageClientFactory {
+    /**
+     * @return a new B2StorageClientFactory that picks whichever of the built-in B2StorageClientFactorys is
+     *         on the java class path.
+     */
+    static B2StorageClientFactory createDefaultFactory() {
+        return new B2StorageClientFactoryPathBasedImpl();
+    }
+
+    /**
+     * @param config the configuration to use.
+     * @return a new B2StorageClient or throws a RuntimeException if it can't make one.
+     */
+    B2StorageClient create(B2ClientConfig config);
+
+    /**
+     * @param applicationKeyId the id of the secret to use to authenticate with the b2 servers
+     * @param applicationKey the secret used to authenticate with the b2 servers.
+     * @param userAgent the user agent to use when performing http requests.
+     * @return a new B2StorageClient or throws a RuntimeException if it can't make one.
+     */
+    default B2StorageClient create(String applicationKeyId, String applicationKey, String userAgent) {
+        final B2AccountAuthorizer accountAuthorizer = B2AccountAuthorizerSimpleImpl
+                .builder(applicationKeyId, applicationKey)
+                .build();
+        final B2ClientConfig config = B2ClientConfig
+                .builder(accountAuthorizer, userAgent)
+                .build();
+        return create(config);
+    }
+
+    /**
+     * Gets the applicationKeyId and applicationKey from the environment and then
+     *
+     * @param userAgent the user agent to use when performing http requests.
+     * @return a new B2StorageClient or throws a RuntimeException if it can't make one.
+     * @throws RuntimeException if there's a problem getting the credentials from the environment or any other
+     *                          problem creating the client.
+     */
+    default B2StorageClient create(String userAgent) {
+        final B2Credentials credentials = B2CredentialsFromEnvironmentSource.build().getCredentials();
+        return create(credentials.getApplicationKeyId(), credentials.getApplicationKey(), userAgent);
+    }
+}

--- a/core/src/main/java/com/backblaze/b2/client/B2StorageClientFactoryPathBasedImpl.java
+++ b/core/src/main/java/com/backblaze/b2/client/B2StorageClientFactoryPathBasedImpl.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019, Backblaze Inc. All Rights Reserved.
+ * License https://www.backblaze.com/using_b2_code.html
+ */
+package com.backblaze.b2.client;
+
+import com.backblaze.b2.util.B2Preconditions;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This implementation of B2StorageClientFactory has a list of registered class names
+ * and instantiates the first one of those classes which can be loaded.
+ *
+ * Instances of this class start out knowing about the class names for all of the
+ * official implementations.  If it makes sense to let code that uses the library
+ * register implementations, we can make registerClass() public, but it's possible
+ * that it'll be easier for them to just make their own factory entirely.
+ *
+ *
+ * THREAD-SAFE.
+ */
+public class B2StorageClientFactoryPathBasedImpl implements B2StorageClientFactory {
+    /**
+     * A list of class names.  Some or most of them might not be loadable,
+     * but, if they are loadable, they must implement B2StorageClientFactory.
+     *
+     * THREAD-SAFETY: Synchronize on the instance before reading or writing this variable.
+     */
+    private List<String> factoryClassNames = new ArrayList<>();
+
+    /**
+     * This is either null or the factory we've found and created using the the factoryClassNames.
+     * Note that once we've picked one, we stick with it, even if it fails.
+     *
+     * THREAD-SAFETY: Synchronize on the instance before reading or writing this variable.
+     */
+    private B2StorageClientFactory factory;
+
+    B2StorageClientFactoryPathBasedImpl() {
+        // register the okhttp-based implementation:
+        //registerClass("com.backblaze.b2.client.okHttpClient.B2StorageOkHttpClientFactory");
+
+        // register the Apache HttpClient-based implementation:
+        registerClass("com.backblaze.b2.client.webApiHttpClient.B2StorageHttpClientFactory");
+
+    }
+
+    /**
+     * @param className the fully-qualified name of a class that implements B2StorageClientFactory and
+     *                  has a no-arguments constructor.
+     */
+    /*forTests*/ synchronized void registerClass(String className) {
+        B2Preconditions.checkArgument(!factoryClassNames.contains(className), className + " was already registered?");
+
+        // adding to the front of the list so that tests can add their own implementations before the built in ones.
+        factoryClassNames.add(0, className);
+    }
+
+    /**
+     * @param config the configuration to use.
+     * @return a new B2StorageClient or throws a RuntimeException if it can't make one.
+     */
+    public synchronized B2StorageClient create(B2ClientConfig config) {
+        if (factory == null) {
+            factory = findAndCreateFactory();
+        }
+
+        return factory.create(config);
+    }
+
+    /**
+     * @return the createDefault() method from the first class in storageClientClassNames.
+     */
+    private synchronized B2StorageClientFactory findAndCreateFactory() {
+        for (String className : factoryClassNames) {
+            try {
+                final Class<?> clazz = Class.forName(className);
+                final Constructor<?> ctor = clazz.getConstructor();
+                final Object factory = ctor.newInstance();
+                if (!(factory instanceof B2StorageClientFactory)) {
+                    throw new RuntimeException(className + " doesn't implement B2StorageClientFactory.");
+                }
+                return (B2StorageClientFactory) factory;
+            } catch (ClassNotFoundException e) {
+                // this is normal.  we usually have entries in the list that aren't in the class path.
+            } catch (NoSuchMethodException e) {
+                // this is a bit surprising.  the class exists, but doesn't have a no-parameter constructor.
+                // that seems like a coding problem in a jar on the path.  go ahead and throw to
+                // help the developer who is working on that class.
+                throw new RuntimeException("class " + className + " doesn't have a public no-argument constructor?", e);
+            } catch (IllegalAccessException | InstantiationException | InvocationTargetException e) {
+                throw new RuntimeException("unable to instantiate " + className + ": " + e, e);
+            }
+        }
+
+        throw new RuntimeException("can't find any of the registered classes.");
+    }
+}

--- a/core/src/test/java/com/backblaze/b2/client/B2StorageClientFactoryPathBasedImplTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2StorageClientFactoryPathBasedImplTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2017, Backblaze Inc. All Rights Reserved.
+ * License https://www.backblaze.com/using_b2_code.html
+ */
+package com.backblaze.b2.client;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockingDetails;
+
+public class B2StorageClientFactoryPathBasedImplTest {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+
+    @Test
+    public void testDefaultFactory_failsBecauseTestEnvironmentDoesntIncludeHttpClientJars() {
+        final B2StorageClientFactory factory = B2StorageClientFactory.createDefaultFactory();
+
+        thrown.expectMessage("can't find any of the registered classes.");
+        factory.create("appKeyId", "appKey", "userAgent");
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    public static class FactoryThatMakesMocks implements B2StorageClientFactory {
+        @Override
+        public B2StorageClient create(B2ClientConfig config) {
+            return mock(B2StorageClient.class);
+        }
+    }
+
+    @Test
+    public void testRegisterClassWorks() {
+        // register the class above.
+        final B2StorageClientFactoryPathBasedImpl factory = new B2StorageClientFactoryPathBasedImpl();
+        factory.registerClass(FactoryThatMakesMocks.class.getName());
+
+        // use the factory.
+        final B2StorageClient client = factory.create("appKeyId", "appKey", "userAgent");
+        assertTrue(mockingDetails(client).isMock());
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    @SuppressWarnings("unused") // used by reflection
+    public static class FactoryWithoutRequiredConstructor implements B2StorageClientFactory {
+        private FactoryWithoutRequiredConstructor() {
+        }
+
+        @Override
+        public B2StorageClient create(B2ClientConfig config) {
+            return null;
+        }
+    }
+
+    @Test
+    public void testRegisteringClassWithoutCorrectConstructor() {
+        final String className = FactoryWithoutRequiredConstructor.class.getName();
+        checkThrows(className,"class " + className + " doesn't have a public no-argument constructor?");
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    @SuppressWarnings({"unused", "WeakerAccess"}) // used by reflection
+    public static class FactoryWithoutRequiredInterface {
+    }
+
+    @Test
+    public void testRegisteringClassWhichDoesntImplementCorrectInterface() {
+        final String className = FactoryWithoutRequiredInterface.class.getName();
+        checkThrows(className,className + " doesn't implement B2StorageClientFactory.");
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    @SuppressWarnings("unused") // used by reflection.
+    public static class FactoryThatThrowsInConstructor implements B2StorageClientFactory {
+
+        public FactoryThatThrowsInConstructor() {
+            throw new RuntimeException("throws in constructor");
+        }
+
+        @Override
+        public B2StorageClient create(B2ClientConfig config) {
+            return mock(B2StorageClient.class);
+        }
+    }
+
+    @Test
+    public void testRegisteringClassWhichThrowsInConstructor() {
+        final String className = FactoryThatThrowsInConstructor.class.getName();
+        checkThrows(className,"unable to instantiate " + className + ": java.lang.reflect.InvocationTargetException");
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    private void checkThrows(String className, String expectedMessage) {
+        final B2StorageClientFactoryPathBasedImpl factory = new B2StorageClientFactoryPathBasedImpl();
+        factory.registerClass(className);
+
+        thrown.expectMessage(expectedMessage);
+        factory.create("appKeyId", "appKey", "userAgent");
+    }
+}

--- a/core/src/test/java/com/backblaze/b2/client/B2StorageClientFactoryTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2StorageClientFactoryTest.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2019, Backblaze Inc. All Rights Reserved.
+ * License https://www.backblaze.com/using_b2_code.html
+ */
+package com.backblaze.b2.client;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class B2StorageClientFactoryTest {
+    @Test
+    public void testCreateDefaultFactory_returnsExpectedImplementation() {
+        final B2StorageClientFactory factory = B2StorageClientFactory.createDefaultFactory();
+        assertNotNull(factory);
+        assertTrue(factory instanceof B2StorageClientFactoryPathBasedImpl);
+    }
+}

--- a/httpclient/src/main/java/com/backblaze/b2/client/webApiHttpClient/B2StorageHttpClientFactory.java
+++ b/httpclient/src/main/java/com/backblaze/b2/client/webApiHttpClient/B2StorageHttpClientFactory.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019, Backblaze Inc. All Rights Reserved.
+ * License https://www.backblaze.com/using_b2_code.html
+ */
+package com.backblaze.b2.client.webApiHttpClient;
+
+import com.backblaze.b2.client.B2ClientConfig;
+import com.backblaze.b2.client.B2StorageClient;
+import com.backblaze.b2.client.B2StorageClientFactory;
+
+/**
+ * Simple factory for the HttpClient-based B2StorageClient.
+ *
+ * THREAD-SAFE.
+ */
+
+public class B2StorageHttpClientFactory implements B2StorageClientFactory {
+
+    @Override
+    public B2StorageClient create(B2ClientConfig config) {
+        return B2StorageHttpClientBuilder.builder(config).build();
+    }
+}

--- a/httpclient/src/test/java/com/backblaze/b2/client/webApiHttpClient/B2StorageHttpClientFactoryTest.java
+++ b/httpclient/src/test/java/com/backblaze/b2/client/webApiHttpClient/B2StorageHttpClientFactoryTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019, Backblaze Inc. All Rights Reserved.
+ * License https://www.backblaze.com/using_b2_code.html
+ */
+package com.backblaze.b2.client.webApiHttpClient;
+
+import com.backblaze.b2.client.B2StorageClient;
+import com.backblaze.b2.client.B2StorageClientFactory;
+import com.backblaze.b2.client.B2StorageClientFactoryPathBasedImpl;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class B2StorageHttpClientFactoryTest {
+
+    @Test
+    public void testCreate() {
+        // this is mostly to keep B2StorageHttpClientFactory from being unused.
+        final B2StorageHttpClientFactory factory = new B2StorageHttpClientFactory();
+        assertNotNull(factory);
+    }
+
+    @Test
+    public void testDefaultFactory_succeedsBecauseTestEnvironmentIncludesHttpClientJars() {
+        final B2StorageClientFactory factory = B2StorageClientFactory.createDefaultFactory();
+        assertTrue(factory instanceof B2StorageClientFactoryPathBasedImpl);
+
+        assertNotNull(factory.create("appKeyId", "appKey", "userAgent"));
+    }
+}

--- a/samples/src/main/java/com/backblaze/b2/sample/B2.java
+++ b/samples/src/main/java/com/backblaze/b2/sample/B2.java
@@ -5,6 +5,7 @@
 package com.backblaze.b2.sample;
 
 import com.backblaze.b2.client.B2StorageClient;
+import com.backblaze.b2.client.B2StorageClientFactory;
 import com.backblaze.b2.client.contentHandlers.B2ContentFileWriter;
 import com.backblaze.b2.client.contentSources.B2ContentSource;
 import com.backblaze.b2.client.contentSources.B2ContentTypes;
@@ -19,9 +20,6 @@ import com.backblaze.b2.client.structures.B2ListFileVersionsRequest;
 import com.backblaze.b2.client.structures.B2Part;
 import com.backblaze.b2.client.structures.B2UpdateBucketRequest;
 import com.backblaze.b2.client.structures.B2UploadFileRequest;
-import com.backblaze.b2.client.webApiHttpClient.B2StorageHttpClientBuilder;
-import com.backblaze.b2.client.webApiHttpClient.HttpClientFactory;
-import com.backblaze.b2.client.webApiHttpClient.HttpClientFactoryImpl;
 import com.backblaze.b2.json.B2Json;
 import com.backblaze.b2.json.B2JsonException;
 import com.backblaze.b2.util.B2ExecutorUtils;
@@ -98,15 +96,9 @@ public class B2 implements AutoCloseable {
     // it's null until the first time getExecutor() is called.
     private ExecutorService executor;
 
-    private B2() throws B2Exception {
+    private B2() {
         out = System.out;
-        final HttpClientFactory httpClientFactory = HttpClientFactoryImpl
-                .builder()
-                .build();
-        client = B2StorageHttpClientBuilder
-                .builder(USER_AGENT)
-                .setHttpClientFactory(httpClientFactory)
-                .build();
+        client = B2StorageClientFactory.createDefaultFactory().create(USER_AGENT);
     }
 
     private ExecutorService getExecutor() {
@@ -568,7 +560,7 @@ public class B2 implements AutoCloseable {
         out.println("  url:  " + client.getDownloadByNameUrl(bucketName, b2Path));
     }
 
-    private void finish_uploading_large_file(String[] args) throws B2Exception, IOException {
+    private void finish_uploading_large_file(String[] args) throws B2Exception {
         // [--noProgress] [--threads N] <bucketName> <largeFileId> <localPath>
         checkArgCount(args, 3, 5);
         final int iLastArg = args.length - 1;

--- a/samples/src/main/java/com/backblaze/b2/sample/B2Sample.java
+++ b/samples/src/main/java/com/backblaze/b2/sample/B2Sample.java
@@ -6,6 +6,7 @@ package com.backblaze.b2.sample;
 
 import com.backblaze.b2.client.B2Sdk;
 import com.backblaze.b2.client.B2StorageClient;
+import com.backblaze.b2.client.B2StorageClientFactory;
 import com.backblaze.b2.client.contentHandlers.B2ContentFileWriter;
 import com.backblaze.b2.client.contentHandlers.B2ContentMemoryWriter;
 import com.backblaze.b2.client.contentSources.B2ByteArrayContentSource;
@@ -31,7 +32,6 @@ import com.backblaze.b2.client.structures.B2Part;
 import com.backblaze.b2.client.structures.B2UpdateBucketRequest;
 import com.backblaze.b2.client.structures.B2UploadFileRequest;
 import com.backblaze.b2.client.structures.B2UploadListener;
-import com.backblaze.b2.client.webApiHttpClient.B2StorageHttpClientBuilder;
 import com.backblaze.b2.util.B2ByteRange;
 import com.backblaze.b2.util.B2ExecutorUtils;
 import com.backblaze.b2.util.B2Preconditions;
@@ -61,7 +61,7 @@ public class B2Sample {
 
         final ExecutorService executor = Executors.newFixedThreadPool(10, createThreadFactory("B2Sample-executor-%02d"));
 
-        try (final B2StorageClient client = B2StorageHttpClientBuilder.builder(USER_AGENT).build()) {
+        try (final B2StorageClient client = B2StorageClientFactory.createDefaultFactory().create(USER_AGENT)) {
             mainGuts(writer, client, executor);
         } finally {
             B2ExecutorUtils.shutdownAndAwaitTermination(executor, 10, 10);


### PR DESCRIPTION
… directly naming an implementation.

we're working on adding an OkHttp-based implementation of B2WebApiClient
and we don't want to have the sample programs have to import a specific
web client implementation.  instead, they can now just say:

   B2StorageClientFactory.createDefaultFactory().create(USER_AGENT)

to create a B2StorageClient with whichever of the known implementations
are in the classpath.  in the future, we can allow people to register
their own classes, if that makes sense.

testing:
  * ./gradlew build javadoc writeNewPom
  * ran the unit tests in IDEA, including with coverage to check new tests.
  * ran B2 and B2Sample to make sure clients were created and usable.
  * Mark will uncomment (and maybe tweak) the OkHttp class registration
    in B2StorageClientFactoryPathBasedImpl then make sure that the sample
    programs work with his new implementation without having to change
    the sample code.