### PR TITLE
Split handler initialization into: constructor and initialize()

### DIFF
--- a/core/src/main/java/com/backblaze/b2/json/B2JsonInitializedTypeHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonInitializedTypeHandler.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019, Backblaze, Inc.  All rights reserved.
+ */
+
+package com.backblaze.b2.json;
+
+import com.backblaze.b2.util.B2Preconditions;
+
+/**
+ * Base class for all implementations of B2JsonTypeHandler that have an initialize() method.
+ *
+ * (De)serialization is expected to be fast, so each implementation class gathers
+ * information it needs when it's set up, so when it's time to run it has all of
+ * the necessary information at hand.  This gets tricky because dependencies between
+ * handlers may have loops.
+ *
+ * The plan is to initialize in two phases:
+ *
+ * First, the constructor, which must not depend on any other handlers, and which
+ * must gather all of the information that other handlers will need.
+ *
+ * Second, the initialize() method does any work that needs information from other
+ * type handlers.
+ *
+ * Both phases are protected by the lock on B2JsonHandlerMap, so they don't need to
+ * lock, and the data they store in the object is guaranteed to be visible without
+ * further locking.
+ *
+ * Methods that return data set during initialize() should include this check:
+ *
+ *     Preconditions.checkState(isInitialized());
+ */
+public abstract class B2JsonInitializedTypeHandler<T> implements B2JsonTypeHandler<T> {
+
+    /**
+     * Has the initialize() method been run?
+     */
+    private boolean initialized = false;
+
+    /**
+     * Does any setup that requires information from other handlers.
+     *
+     * This is package-private; we only expect this to be called from B2JsonHandlerMap
+     * while it holds its lock.
+     */
+    void initialize(B2JsonHandlerMap b2JsonHandlerMap) throws B2JsonException {
+        B2Preconditions.checkState(!initialized);
+        initializeImplementation(b2JsonHandlerMap);
+        initialized = true;
+    }
+
+    /**
+     * Does any initialization specific to the concrete class.
+     *
+     * Override in classes that need to gather information from other handlers.
+     */
+    protected void initializeImplementation(B2JsonHandlerMap b2JsonHandlerMap) throws B2JsonException {}
+
+    /**
+     * Has the initialize method run?
+     * @return
+     */
+    protected boolean isInitialized() {
+        return initialized;
+    }
+}

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonInitializedTypeHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonInitializedTypeHandler.java
@@ -30,6 +30,9 @@ import com.backblaze.b2.util.B2Preconditions;
  * Methods that return data set during initialize() should include this check:
  *
  *     Preconditions.checkState(isInitialized());
+ *
+ * NOTE: adding the initialize() method to BzJsonTypeHandler would change the interface
+ * and break any clients who have written then own handlers.
  */
 public abstract class B2JsonInitializedTypeHandler<T> implements B2JsonTypeHandler<T> {
 
@@ -59,7 +62,6 @@ public abstract class B2JsonInitializedTypeHandler<T> implements B2JsonTypeHandl
 
     /**
      * Has the initialize method run?
-     * @return
      */
     protected boolean isInitialized() {
         return initialized;

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonInitializedTypeHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonInitializedTypeHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Backblaze, Inc.  All rights reserved.
+ * Copyright 2019, Backblaze Inc. All Rights Reserved.
  * License https://www.backblaze.com/using_b2_code.html
  */
 

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonInitializedTypeHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonInitializedTypeHandler.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2019, Backblaze, Inc.  All rights reserved.
+ * License https://www.backblaze.com/using_b2_code.html
  */
 
 package com.backblaze.b2.json;

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonNonUrlTypeHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonNonUrlTypeHandler.java
@@ -8,7 +8,7 @@ package com.backblaze.b2.json;
 /**
  * Base class for handlers that don't support reading URL parameters.
  */
-public abstract class B2JsonNonUrlTypeHandler<T> implements B2JsonTypeHandler<T> {
+public abstract class B2JsonNonUrlTypeHandler<T> extends B2JsonInitializedTypeHandler<T> {
 
     public T deserializeUrlParam(String urlValue) throws B2JsonException {
         throw new B2JsonException("type not supported in URL parameter");

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonObjectHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonObjectHandler.java
@@ -124,7 +124,7 @@ public class B2JsonObjectHandler<T> extends B2JsonNonUrlTypeHandler<T> {
         // Get information on all of the fields in the class.
         for (Field field : getObjectFieldsForJson(clazz)) {
             final FieldRequirement requirement = getFieldRequirement(clazz, field);
-            final B2JsonTypeHandler<?> handler = getFieldHandler(field.getGenericType(), handlerMap);
+            final B2JsonTypeHandler<?> handler = getUninitializedFieldHandler(field.getGenericType(), handlerMap);
             final Object defaultValueOrNull = getDefaultValueOrNull(field, handler);
             final VersionRange versionRange = getVersionRange(field);
             final boolean isSensitive = field.getAnnotation(B2Json.sensitive.class) != null;
@@ -260,47 +260,47 @@ public class B2JsonObjectHandler<T> extends B2JsonNonUrlTypeHandler<T> {
         }
     }
 
-    private B2JsonTypeHandler getFieldHandler(Type fieldType, B2JsonHandlerMap handlerMap) throws B2JsonException {
+    private B2JsonTypeHandler getUninitializedFieldHandler(Type fieldType, B2JsonHandlerMap handlerMap) throws B2JsonException {
         if (fieldType instanceof ParameterizedType) {
             ParameterizedType paramType = (ParameterizedType) fieldType;
             final Class rawType = (Class) paramType.getRawType();
             if (rawType == LinkedHashSet.class) {
                 Type itemType = paramType.getActualTypeArguments()[0];
-                B2JsonTypeHandler<?> itemHandler = getFieldHandler(itemType, handlerMap);
+                B2JsonTypeHandler<?> itemHandler = getUninitializedFieldHandler(itemType, handlerMap);
                 return new B2JsonLinkedHashSetHandler(itemHandler);
             }
             if (rawType == List.class) {
                 Type itemType = paramType.getActualTypeArguments()[0];
-                B2JsonTypeHandler<?> itemHandler = getFieldHandler(itemType, handlerMap);
+                B2JsonTypeHandler<?> itemHandler = getUninitializedFieldHandler(itemType, handlerMap);
                 return new B2JsonListHandler(itemHandler);
             }
             if (rawType == TreeSet.class) {
                 Type itemType = paramType.getActualTypeArguments()[0];
-                B2JsonTypeHandler<?> itemHandler = getFieldHandler(itemType, handlerMap);
+                B2JsonTypeHandler<?> itemHandler = getUninitializedFieldHandler(itemType, handlerMap);
                 return new B2JsonTreeSetHandler(itemHandler);
             }
             if (rawType == Set.class) {
                 Type itemType = paramType.getActualTypeArguments()[0];
-                B2JsonTypeHandler<?> itemHandler = getFieldHandler(itemType, handlerMap);
+                B2JsonTypeHandler<?> itemHandler = getUninitializedFieldHandler(itemType, handlerMap);
                 return new B2JsonSetHandler(itemHandler);
             }
             if (rawType == EnumSet.class) {
                 Type itemType = paramType.getActualTypeArguments()[0];
-                B2JsonTypeHandler<?> itemHandler = getFieldHandler(itemType, handlerMap);
+                B2JsonTypeHandler<?> itemHandler = getUninitializedFieldHandler(itemType, handlerMap);
                 return new B2JsonEnumSetHandler(itemHandler);
             }
             if (rawType == Map.class || rawType == TreeMap.class) {
                 Type keyType = paramType.getActualTypeArguments()[0];
                 Type valueType = paramType.getActualTypeArguments()[1];
-                B2JsonTypeHandler<?> keyHandler = getFieldHandler(keyType, handlerMap);
-                B2JsonTypeHandler<?> valueHandler = getFieldHandler(valueType, handlerMap);
+                B2JsonTypeHandler<?> keyHandler = getUninitializedFieldHandler(keyType, handlerMap);
+                B2JsonTypeHandler<?> valueHandler = getUninitializedFieldHandler(valueType, handlerMap);
                 return new B2JsonMapHandler(keyHandler, valueHandler);
             }
             if (rawType == ConcurrentMap.class) {
                 Type keyType = paramType.getActualTypeArguments()[0];
                 Type valueType = paramType.getActualTypeArguments()[1];
-                B2JsonTypeHandler<?> keyHandler = getFieldHandler(keyType, handlerMap);
-                B2JsonTypeHandler<?> valueHandler = getFieldHandler(valueType, handlerMap);
+                B2JsonTypeHandler<?> keyHandler = getUninitializedFieldHandler(keyType, handlerMap);
+                B2JsonTypeHandler<?> valueHandler = getUninitializedFieldHandler(valueType, handlerMap);
                 return new B2JsonConcurrentMapHandler(keyHandler, valueHandler);
             }
         }

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonUnionBaseHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonUnionBaseHandler.java
@@ -101,7 +101,7 @@ public class B2JsonUnionBaseHandler<T> extends B2JsonNonUrlTypeHandler<T> {
             if (!hasSuperclass(typeClass, clazz)) { // use clazz.isAssignableFrom(typeClass)?
                 throw new B2JsonException(typeClass + " is not a subclass of " + clazz);
             }
-            final B2JsonTypeHandler<?> handler = b2JsonHandlerMap.getHandler(typeClass);
+            final B2JsonTypeHandler<?> handler = b2JsonHandlerMap.getUninitializedHandler(typeClass);
             if (handler instanceof B2JsonObjectHandler) {
                 typeNameToHandler.put(typeName, (B2JsonObjectHandler) handler);
                 classToHandler.put(typeClass, (B2JsonObjectHandler) handler);

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonUnionBaseHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonUnionBaseHandler.java
@@ -5,6 +5,8 @@
 
 package com.backblaze.b2.json;
 
+import com.backblaze.b2.util.B2Preconditions;
+
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
@@ -37,12 +39,12 @@ public class B2JsonUnionBaseHandler<T> extends B2JsonNonUrlTypeHandler<T> {
     /**
      * Mapping from type name (in the type name field of a serialized object) to class.
      */
-    private final Map<String, B2JsonObjectHandler<?>> typeNameToHandler;
+    private Map<String, B2JsonObjectHandler<?>> typeNameToHandler;
 
     /**
      * Mapping from registered classes to their handlers.
      */
-    private final Map<Class<?>, B2JsonObjectHandler<?>> classToHandler;
+    private Map<Class<?>, B2JsonObjectHandler<?>> classToHandler;
 
     /**
      * Handlers for all of the fields in all of the subclasses.
@@ -51,10 +53,10 @@ public class B2JsonUnionBaseHandler<T> extends B2JsonNonUrlTypeHandler<T> {
      * with the same name must be of the same type.  This allows us to de-serialize
      * the fields before we know which subclass they belong to.
      */
-    private final Map<String, B2JsonTypeHandler<?>> fieldNameToHandler;
+    private Map<String, B2JsonTypeHandler<?>> fieldNameToHandler;
 
 
-    /*package*/ B2JsonUnionBaseHandler(Class<T> clazz, B2JsonHandlerMap handlerMap) throws B2JsonException {
+    /*package*/ B2JsonUnionBaseHandler(Class<T> clazz) throws B2JsonException {
 
         this.clazz = clazz;
 
@@ -81,6 +83,12 @@ public class B2JsonUnionBaseHandler<T> extends B2JsonNonUrlTypeHandler<T> {
         final B2Json.union union = clazz.getAnnotation(B2Json.union.class);
         this.typeNameField = union.typeField();
 
+
+    }
+
+    @Override
+    protected void initializeImplementation(B2JsonHandlerMap b2JsonHandlerMap) throws B2JsonException {
+
         // Get the map of type name to class of all the members of the union.
         final Map<String, Class<?>> typeNameToClass = getUnionTypeMap(clazz).getTypeNameToClass();
 
@@ -93,7 +101,7 @@ public class B2JsonUnionBaseHandler<T> extends B2JsonNonUrlTypeHandler<T> {
             if (!hasSuperclass(typeClass, clazz)) { // use clazz.isAssignableFrom(typeClass)?
                 throw new B2JsonException(typeClass + " is not a subclass of " + clazz);
             }
-            final B2JsonTypeHandler<?> handler = handlerMap.getHandler(typeClass);
+            final B2JsonTypeHandler<?> handler = b2JsonHandlerMap.getHandler(typeClass);
             if (handler instanceof B2JsonObjectHandler) {
                 typeNameToHandler.put(typeName, (B2JsonObjectHandler) handler);
                 classToHandler.put(typeClass, (B2JsonObjectHandler) handler);
@@ -108,10 +116,9 @@ public class B2JsonUnionBaseHandler<T> extends B2JsonNonUrlTypeHandler<T> {
         fieldNameToHandler = new HashMap<>();
         final Map<String, String> fieldNameToSourceClassName = new HashMap<>();
         for (Class<?> subclass : typeNameToClass.values()) {
-            B2JsonObjectHandler<?> subclassHandler = (B2JsonObjectHandler<?>) handlerMap.getHandler(subclass);
-            for (FieldInfo fieldInfo : subclassHandler.getFieldMap().values()) {
-                final String fieldName = fieldInfo.getName();
-                final B2JsonTypeHandler handler = fieldInfo.getHandler();
+            for (Field field : B2JsonObjectHandler.getObjectFieldsForJson(subclass)) {
+                final String fieldName = field.getName();
+                final B2JsonTypeHandler handler = b2JsonHandlerMap.getUninitializedHandler(field.getType());
                 if (fieldNameToHandler.containsKey(fieldName)) {
                     // We have seen this field name before.  Throw an error if the type is different
                     // than before.
@@ -205,6 +212,9 @@ public class B2JsonUnionBaseHandler<T> extends B2JsonNonUrlTypeHandler<T> {
 
     @Override
     public void serialize(T obj, B2JsonOptions options, B2JsonWriter out) throws IOException, B2JsonException {
+
+        B2Preconditions.checkState(isInitialized());
+
         if (obj.getClass() == clazz) {
             // the union base class is basically "abstract" and can't be serialized.
             throw new B2JsonException("" + clazz + " is a union base class, and cannot be serialized");
@@ -227,6 +237,8 @@ public class B2JsonUnionBaseHandler<T> extends B2JsonNonUrlTypeHandler<T> {
 
     @Override
     public T deserialize(B2JsonReader in, B2JsonOptions options) throws B2JsonException, IOException {
+
+        B2Preconditions.checkState(isInitialized());
 
         // Gather the values of all fields present, and also the name of the type of object to create.
         String typeName = null;

--- a/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
+++ b/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
@@ -2080,4 +2080,30 @@ public class B2JsonTest extends B2BaseTest {
         }
     }
 
+    @Test
+    public void testRecursiveUnion() {
+        final String json = B2Json.toJsonOrThrowRuntime(new RecursiveUnionNode(new RecursiveUnionNode(null)));
+        B2Json.fromJsonOrThrowRuntime(json, RecursiveUnion.class);
+    }
+
+    @B2Json.union(typeField = "type")
+    private static class RecursiveUnion {
+        public static B2JsonUnionTypeMap getUnionTypeMap() throws B2JsonException {
+            return B2JsonUnionTypeMap
+                    .builder()
+                    .put("node", RecursiveUnionNode.class)
+                    .build();
+        }
+    }
+
+    private static class RecursiveUnionNode extends RecursiveUnion {
+
+        @B2Json.optional
+        private final RecursiveUnion recursiveUnion;
+
+        @B2Json.constructor(params = "recursiveUnion")
+        private RecursiveUnionNode(RecursiveUnion recursiveUnion) {
+            this.recursiveUnion = recursiveUnion;
+        }
+    }
 }


### PR DESCRIPTION
This fixes the bug where you could not use union types that were
recursive.  There's now a test case for this.

There was some confusing code to handle recursive object types that
put handlers in the map halfway through their constructors.  Giving
access to an object before it's constructed is bad practice, and
confusing.  Now, there are two phases of initialization: the constructor
and an initialize() method.  And the object doesn't leak out during
the constructor.  The B2JsonInitializedTypeHandler javadoc describes
the rules about what happens when.

This makes it clear what you cannot look at other handlers in your
constructor, and what fields you're allowed to look at in other
handlers in your initialize() method.

Testing: all tests