### PR TITLE
Address issue #46, and improve default value handling

### DIFF
--- a/core/src/main/java/com/backblaze/b2/json/B2Json.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2Json.java
@@ -463,6 +463,17 @@ public class B2Json {
     }
 
     /**
+     * <p>Class annotation that applies to a class that is a @union.</p>
+     *
+     * <p>The value provided when de-serializing and the type is unknown.</p>
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    public @interface defaultForUnknownType {
+        String value();
+    }
+
+    /**
      * Field annotation that says a field is required to be present.
      */
     @Retention(RetentionPolicy.RUNTIME)

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonInitializedTypeHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonInitializedTypeHandler.java
@@ -35,7 +35,7 @@ import com.backblaze.b2.util.B2Preconditions;
  *     Preconditions.checkState(isInitialized());
  *
  * NOTE: adding the initialize() method to BzJsonTypeHandler would change the interface
- * and break any clients who have written then own handlers.
+ * and break any clients who have written their own handlers.
  */
 public abstract class B2JsonInitializedTypeHandler<T> implements B2JsonTypeHandler<T> {
 

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonInitializedTypeHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonInitializedTypeHandler.java
@@ -66,4 +66,9 @@ public abstract class B2JsonInitializedTypeHandler<T> implements B2JsonTypeHandl
     protected boolean isInitialized() {
         return initialized;
     }
+
+    /**
+     * Checks that all default values used by this class are valid and can be deserialized.
+     */
+    void checkDefaultValues() throws B2JsonException {}
 }

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonInitializedTypeHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonInitializedTypeHandler.java
@@ -15,7 +15,7 @@ import com.backblaze.b2.util.B2Preconditions;
  * the necessary information at hand.  This gets tricky because dependencies between
  * handlers may have loops.
  *
- * The plan is to initialize in two phases:
+ * The plan is to initialize in three phases:
  *
  * First, the constructor, which must not depend on any other handlers, and which
  * must gather all of the information that other handlers will need.
@@ -23,7 +23,10 @@ import com.backblaze.b2.util.B2Preconditions;
  * Second, the initialize() method does any work that needs information from other
  * type handlers.
  *
- * Both phases are protected by the lock on B2JsonHandlerMap, so they don't need to
+ * Third, check the validity of default values, now that all type handlers have
+ * gone through at least the second phase.
+ *
+ * All phases are protected by the lock on B2JsonHandlerMap, so they don't need to
  * lock, and the data they store in the object is guaranteed to be visible without
  * further locking.
  *

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonObjectHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonObjectHandler.java
@@ -580,6 +580,11 @@ public class B2JsonObjectHandler<T> extends B2JsonNonUrlTypeHandler<T> {
                                         B2JsonOptions.DEFAULT
                                 );
                     } catch (IOException e) {
+                        // This should never happen.  We should have checked default values
+                        // in B2JsonHandlerMap right after initializing the handlers and before
+                        // anybody tried to use them.  OTOH, if de-serializing a default value
+                        // uses the default values in other types, we could hit this while
+                        // checking default values in B2JsonHandlerMap.
                         throw new B2JsonException(e.getMessage());
                     }
                 }

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonUnionBaseHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonUnionBaseHandler.java
@@ -273,7 +273,7 @@ public class B2JsonUnionBaseHandler<T> extends B2JsonNonUrlTypeHandler<T> {
 
         B2Preconditions.checkState(isInitialized());
 
-        // Place to hold the name of one of the unknow fields, if there are any.
+        // Place to hold the name of one of the unknown fields, if there are any.
         // We don't want to throw an error about them until we're sure the type is
         // known.  And we only need the name of one to throw an exception, so there
         // is no need to keep a list of them.

--- a/core/src/main/java/com/backblaze/b2/json/FieldInfo.java
+++ b/core/src/main/java/com/backblaze/b2/json/FieldInfo.java
@@ -21,7 +21,7 @@ public final class FieldInfo implements Comparable<FieldInfo> {
     public final Field field;
     public final B2JsonTypeHandler handler;
     public final FieldRequirement requirement;
-    public final Object defaultValueOrNull;
+    public final String defaultValueJsonOrNull;
     public final VersionRange versionRange;
     public int constructorArgIndex;
     public long bit;
@@ -30,14 +30,14 @@ public final class FieldInfo implements Comparable<FieldInfo> {
     /*package*/ FieldInfo(
             Field field, B2JsonTypeHandler<?> handler,
             FieldRequirement requirement,
-            Object defaultValueOrNull,
+            String defaultValueJsonOrNull,
             VersionRange versionRange,
             boolean isSensitive
     ) {
         this.field = field;
         this.handler =  handler;
         this.requirement = requirement;
-        this.defaultValueOrNull = defaultValueOrNull;
+        this.defaultValueJsonOrNull = defaultValueJsonOrNull;
         this.versionRange = versionRange;
         this.isSensitive = isSensitive;
 

--- a/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
+++ b/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
@@ -1349,7 +1349,7 @@ public class B2JsonTest extends B2BaseTest {
         // Any use of the class with B2Json should trigger the exception.  Even
         // serializing will need to initialize the handler, which should trigger
         // an error.
-        thrown.expectMessage("error in default value for OptionalWithDefaultInvalidValue.count: xxx");
+        thrown.expectMessage("error in default value for OptionalWithDefaultInvalidValue.count: Bad number");
         B2Json.get().toJson(new OptionalWithDefaultInvalidValue(0));
     }
 
@@ -1559,6 +1559,80 @@ public class B2JsonTest extends B2BaseTest {
         final ContainsUnion container = new ContainsUnion(unregistered);
         thrown.expectMessage("class com.backblaze.b2.json.B2JsonTest$SubclassUnregistered isn't a registered part of union class com.backblaze.b2.json.B2JsonTest$UnionAZ");
         B2Json.get().toJson(container);
+    }
+
+    @B2Json.union(typeField = "type")
+    @B2Json.defaultForUnknownType(value = "{\"type\": \"a\", \"n\": 5}")
+    private static class UnionWithDefault {
+        public static B2JsonUnionTypeMap getUnionTypeMap() throws B2JsonException {
+            return B2JsonUnionTypeMap
+                    .builder()
+                    .put("a", UnionWithDefaultClassA.class)
+                    .build();
+        }
+    }
+
+    private static class UnionWithDefaultClassA extends UnionWithDefault {
+        @B2Json.required
+        private final int n;
+
+        @B2Json.constructor(params = "n")
+        private UnionWithDefaultClassA(int n) {
+            this.n = n;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            UnionWithDefaultClassA that = (UnionWithDefaultClassA) o;
+            return n == that.n;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(n);
+        }
+    }
+
+    @Test
+    public void testUnionWithDefault() throws B2JsonException {
+        assertEquals(
+                new UnionWithDefaultClassA(5), // the default value
+                B2Json.get().fromJson("{\"type\": \"unknown\"}", UnionWithDefault.class)
+        );
+        assertEquals(
+                new UnionWithDefaultClassA(99), // NOT the default value; the value provided
+                B2Json.get().fromJson("{\"type\": \"a\", \"n\": 99}", UnionWithDefault.class)
+        );
+    }
+
+    @B2Json.union(typeField = "type")
+    @B2Json.defaultForUnknownType(value = "{\"type\": \"a\", \"n\": 5}")
+    private static class UnionWithInvalidDefault {
+        public static B2JsonUnionTypeMap getUnionTypeMap() throws B2JsonException {
+            return B2JsonUnionTypeMap
+                    .builder()
+                    .put("a", UnionWithInvalidDefaultClassA.class)
+                    .build();
+        }
+    }
+
+    private static class UnionWithInvalidDefaultClassA extends UnionWithInvalidDefault {
+        @B2Json.constructor(params = "")
+        UnionWithInvalidDefaultClassA() {}
+    }
+
+    @Test
+    public void testUnionWithInvalidDefault() throws B2JsonException {
+        // The error should be caught when the class is first used, even if the default
+        // isn't used.
+        thrown.expectMessage("error in default value for union UnionWithInvalidDefault: unknown field 'n' in union type UnionWithInvalidDefault");
+        B2Json.get().toJson(new UnionWithInvalidDefaultClassA());
     }
 
     @B2Json.union(typeField = "type")

--- a/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
+++ b/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
@@ -1334,6 +1334,25 @@ public class B2JsonTest extends B2BaseTest {
         }
     }
 
+    private static class OptionalWithDefaultInvalidValue {
+        @B2Json.optionalWithDefault(defaultValue = "xxx")
+        private final int count;
+
+        @B2Json.constructor(params = "count")
+        private OptionalWithDefaultInvalidValue(int count) {
+            this.count = count;
+        }
+    }
+
+    @Test
+    public void testInvalidValueInOptionalWithDefault() throws B2JsonException {
+        // Any use of the class with B2Json should trigger the exception.  Even
+        // serializing will need to initialize the handler, which should trigger
+        // an error.
+        thrown.expectMessage("error in default value for OptionalWithDefaultInvalidValue.count: xxx");
+        B2Json.get().toJson(new OptionalWithDefaultInvalidValue(0));
+    }
+
     @Test
     public void testVersionRangeBackwards() throws B2JsonException {
         thrown.expectMessage("last version 1 is before first version 2 in class com.backblaze.b2.json.B2JsonTest$VersionRangeBackwardsClass");

--- a/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
+++ b/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
@@ -1529,7 +1529,7 @@ public class B2JsonTest extends B2BaseTest {
 
     @Test
     public void testUnknownFieldInUnion() throws B2JsonException {
-        final String json = "{ \"badField\" : 5 }";
+        final String json = "{ \"badField\" : 5, \"type\": \"a\" }";
         thrown.expectMessage("unknown field 'badField' in union type UnionAZ");
         B2Json.get().fromJson(json, UnionAZ.class);
     }
@@ -1604,6 +1604,10 @@ public class B2JsonTest extends B2BaseTest {
         assertEquals(
                 new UnionWithDefaultClassA(5), // the default value
                 B2Json.get().fromJson("{\"type\": \"unknown\"}", UnionWithDefault.class)
+        );
+        assertEquals(
+                new UnionWithDefaultClassA(5), // the default value
+                B2Json.get().fromJson("{\"type\": \"unknown\", \"unknownField\": 5}", UnionWithDefault.class)
         );
         assertEquals(
                 new UnionWithDefaultClassA(99), // NOT the default value; the value provided


### PR DESCRIPTION
#46

You can now provide a default value to use in a union when an unknown type is found.

Also, default values are now deserialized each time they are used, which is safer if the values are mutable.
