### PR TITLE
Fix bug with Sets contained in unions.

### DIFF
--- a/core/src/main/java/com/backblaze/b2/json/B2Json.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2Json.java
@@ -100,7 +100,7 @@ public class B2Json {
      * Initializes a new B2Json object with handlers for all of the
      * classes that are handled specially.
      */
-    private B2Json() {
+    /*testing*/ B2Json() {
         this.handlerMap = new B2JsonHandlerMap();
     }
 

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonObjectHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonObjectHandler.java
@@ -260,7 +260,10 @@ public class B2JsonObjectHandler<T> extends B2JsonNonUrlTypeHandler<T> {
         }
     }
 
-    private B2JsonTypeHandler getUninitializedFieldHandler(Type fieldType, B2JsonHandlerMap handlerMap) throws B2JsonException {
+    /**
+     * Returns the type for a field in an object.  Used in this class, and also in B2JsonUnionBaseHandler.
+     */
+    /*package*/ static B2JsonTypeHandler getUninitializedFieldHandler(Type fieldType, B2JsonHandlerMap handlerMap) throws B2JsonException {
         if (fieldType instanceof ParameterizedType) {
             ParameterizedType paramType = (ParameterizedType) fieldType;
             final Class rawType = (Class) paramType.getRawType();

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonUnionBaseHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonUnionBaseHandler.java
@@ -116,10 +116,10 @@ public class B2JsonUnionBaseHandler<T> extends B2JsonNonUrlTypeHandler<T> {
         fieldNameToHandler = new HashMap<>();
         final Map<String, String> fieldNameToSourceClassName = new HashMap<>();
         for (Class<?> subclass : typeNameToClass.values()) {
-            for (Field field : B2JsonObjectHandler.getObjectFieldsForJson(subclass)) {
+            for (Field field : B2JsonHandlerMap.getObjectFieldsForJson(subclass)) {
                 final String fieldName = field.getName();
                 final B2JsonTypeHandler handler =
-                        B2JsonObjectHandler.getUninitializedFieldHandler(
+                        B2JsonHandlerMap.getUninitializedFieldHandler(
                                 field.getGenericType(),
                                 b2JsonHandlerMap
                         );

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonUnionBaseHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonUnionBaseHandler.java
@@ -118,7 +118,11 @@ public class B2JsonUnionBaseHandler<T> extends B2JsonNonUrlTypeHandler<T> {
         for (Class<?> subclass : typeNameToClass.values()) {
             for (Field field : B2JsonObjectHandler.getObjectFieldsForJson(subclass)) {
                 final String fieldName = field.getName();
-                final B2JsonTypeHandler handler = b2JsonHandlerMap.getUninitializedHandler(field.getType());
+                final B2JsonTypeHandler handler =
+                        B2JsonObjectHandler.getUninitializedFieldHandler(
+                                field.getGenericType(),
+                                b2JsonHandlerMap
+                        );
                 if (fieldNameToHandler.containsKey(fieldName)) {
                     // We have seen this field name before.  Throw an error if the type is different
                     // than before.

--- a/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
+++ b/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
@@ -162,6 +162,7 @@ public class B2JsonTest extends B2BaseTest {
         final String json =
                 "{\n" +
                         "  \"a\": 5,\n" +
+                        "  \"b\": null,\n" +
                         "  \"type\": \"a\"\n" +
                         "}";
         checkDeserializeSerialize(json, UnionAZ.class);
@@ -180,10 +181,19 @@ public class B2JsonTest extends B2BaseTest {
     /**
      * Regression test to make sure that when handlers are created from
      * B2JsonUnionHandler they work properly.
+     *
+     * This test makes a new B2Json, and deserializes the union type, so
+     * it's sure that the
      */
     @Test
     public void testUnionCreatesHandlers() throws B2JsonException {
-        (new B2Json()).fromJson("{}", UnionAZ.class);
+        (new B2Json()).fromJson("{\n" +
+                "  \"type\": \"a\",\n" +
+                "  \"a\": 5,\n" +
+                "  \"b\": [10]" +
+                "}",
+                UnionAZ.class
+        );
     }
 
     @Test
@@ -1530,6 +1540,7 @@ public class B2JsonTest extends B2BaseTest {
         final String origJson = "{\n" +
                 "  \"contained\": {\n" +
                 "    \"a\": 1,\n" +
+                "    \"b\": null,\n" +
                 "    \"type\": \"a\"\n" +
                 "  }\n" +
                 "}";
@@ -1568,10 +1579,10 @@ public class B2JsonTest extends B2BaseTest {
         public final int a;
 
         @B2Json.optional
-        public final Set<String> b;
+        public final Set<Integer> b;
 
         @B2Json.constructor(params = "a, b")
-        private SubclassA(int a, Set<String> b) {
+        private SubclassA(int a, Set<Integer> b) {
             this.a = a;
             this.b = b;
         }

--- a/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
+++ b/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
@@ -182,8 +182,9 @@ public class B2JsonTest extends B2BaseTest {
      * Regression test to make sure that when handlers are created from
      * B2JsonUnionHandler they work properly.
      *
-     * This test makes a new B2Json, and deserializes the union type, so
-     * it's sure that the
+     * This test makes a new B2Json, and de-serializes the union type, so
+     * it's sure that the B2JsonUnionBaseHandler gets initialized first,
+     * which is what triggered the bug.
      */
     @Test
     public void testUnionCreatesHandlers() throws B2JsonException {

--- a/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
+++ b/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -174,6 +175,15 @@ public class B2JsonTest extends B2BaseTest {
                 "  \"z\": \"hello\"\n" +
                 "}";
         checkDeserializeSerialize(json, UnionAZ.class);
+    }
+
+    /**
+     * Regression test to make sure that when handlers are created from
+     * B2JsonUnionHandler they work properly.
+     */
+    @Test
+    public void testUnionCreatesHandlers() throws B2JsonException {
+        (new B2Json()).fromJson("{}", UnionAZ.class);
     }
 
     @Test
@@ -1557,9 +1567,13 @@ public class B2JsonTest extends B2BaseTest {
         @B2Json.required
         public final int a;
 
-        @B2Json.constructor(params = "a")
-        private SubclassA(int a) {
+        @B2Json.optional
+        public final Set<String> b;
+
+        @B2Json.constructor(params = "a, b")
+        private SubclassA(int a, Set<String> b) {
             this.a = a;
+            this.b = b;
         }
     }
 


### PR DESCRIPTION
When the `B2JsonUnionBaseHandler` gets the handler for a field, it
needs to use the same logic that `B2JsonObjectHandler` uses to create
the handler for a field.
    
This worked before the change to allow recursive unions because the fields
were pulled from the object handlers, which had already been initialized
when the union was set up.  The union can no longer assume that, so it
needs to get the un-initialized the field handlers itself.
    
Testing: new unit test
