### PR TITLE
Fix bug that can leave an uninitialized handler in the map.

### DIFF
--- a/core/src/test/java/com/backblaze/b2/json/B2JsonHandlerMapTest.java
+++ b/core/src/test/java/com/backblaze/b2/json/B2JsonHandlerMapTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019, Backblaze, Inc.  All rights reserved.
+ */
+
+package com.backblaze.b2.json;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.HashSet;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.*;
+
+public class B2JsonHandlerMapTest {
+
+    @Rule
+    public ExpectedException thrown  = ExpectedException.none();
+
+    /**
+     * When there's an error, it should not leave an uninitialized handler in the map.
+     *
+     * This a regression test for a bug where a handler was left in the map even though
+     * its initialize() method threw an exception.
+     */
+    @Test
+    public void testBadClassNotLeftInMap() {
+        final B2JsonHandlerMap handlerMap = new B2JsonHandlerMap();
+
+        try {
+            handlerMap.getHandler(BadClassHolder.class);
+            fail("should have thrown");
+        } catch (Throwable t) {
+            assertThat(t.getMessage(), containsString("BadClass has no constructor annotated with B2Json.constructor"));
+        }
+
+        try {
+            handlerMap.getHandler(BadClassHolder.class);
+            fail("should have thrown");
+        } catch (Throwable t) {
+            assertThat(t.getMessage(), containsString("BadClass has no constructor annotated with B2Json.constructor"));
+        }
+    }
+
+    private static class BadClassHolder {
+        @B2Json.required
+        private final BadClass badClass;
+
+        @B2Json.constructor(params = "badClass")
+        public BadClassHolder(BadClass badClass) {
+            this.badClass = badClass;
+        }
+    }
+
+    private static class BadClass {
+        @B2Json.required
+        private int n;
+
+        // error: no constructor
+    }
+
+    /**
+     * The standard collections classes should not work at the top level.
+     *
+     * Ths is a regression test for a bug that was letting them slip through, but then
+     * not serializing them properly.
+     */
+    @Test
+    public void testSet() throws B2JsonException {
+        final B2JsonHandlerMap handlerMap = new B2JsonHandlerMap();
+
+        thrown.expectMessage("java.util.HashSet.map should have exactly one annotation");
+        handlerMap.getHandler(HashSet.class);
+    }
+
+}


### PR DESCRIPTION
If the initialize() method for a handler threw an exception, the
handler was not initialized, but the getHandler() method left it
in the map.  There's now a test for that case, and some cleanup
code to remove handlers from the map if there's an error.

Also, add a test for HashSet being disallowed.

Testing: unit tests