### PR TITLE
Adding an omitNull parameter to @B2Json.optional

### DIFF
--- a/core/src/main/java/com/backblaze/b2/json/B2Json.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2Json.java
@@ -484,8 +484,9 @@ public class B2Json {
      * Field annotation that says a field is optional.  The value will
      * always be included, even if it is null, when omitNull is false
      * (default); when omitNull is true and the field value is null,
-     * the value will not be included. Plain data types (e.g. int or
-     * double) will always be included as they are not nullable.
+     * the value will not be included. A B2JsonException is thrown
+     * when omitNull is set to true on a primitive field; primitives
+     * are not nullable objects so omitNull does not apply.
      * When deserializing, null/false/0 will be passed to
      * the constructor if the value is not present in the JSON.
      */

--- a/core/src/main/java/com/backblaze/b2/json/B2Json.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2Json.java
@@ -482,13 +482,18 @@ public class B2Json {
 
     /**
      * Field annotation that says a field is optional.  The value will
-     * always be included, even if it is null.  When deserializing,
-     * null/false/0 will be passed to the constructor if the value is
-     * not present in the JSON.
+     * always be included, even if it is null, when omitNull is false
+     * (default); when omitNull is true and the field value is null,
+     * the value will not be included. Plain data types (e.g. int or
+     * double) will always be included as they are not nullable.
+     * When deserializing, null/false/0 will be passed to
+     * the constructor if the value is not present in the JSON.
      */
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.FIELD)
-    public @interface optional {}
+    public @interface optional {
+        boolean omitNull() default false;
+    }
 
     /**
      * Field annotation that says a field is optional.  The value will

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonObjectHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonObjectHandler.java
@@ -215,11 +215,20 @@ public class B2JsonObjectHandler<T> extends B2JsonNonUrlTypeHandler<T> {
      * @param field field definition
      * @return whether the field has the omitNull property
      */
-    private static boolean omitNull(Field field) {
-        B2Json.optional optionalAnnotation = field.getAnnotation(B2Json.optional.class);
+    private boolean omitNull(Field field) throws B2JsonException {
+        final B2Json.optional optionalAnnotation = field.getAnnotation(B2Json.optional.class);
 
         if (optionalAnnotation != null) {
-            return optionalAnnotation.omitNull();
+            final boolean omitNull = optionalAnnotation.omitNull();
+            // omitNull can only be set on non-primitive classes
+            if (omitNull && field.getType().isPrimitive()) {
+                final String message = String.format(
+                        "Field %s.%s declared with 'omitNull = true' but is a primitive type",
+                        this.clazz.getSimpleName(),
+                        field.getName());
+                throw new B2JsonException(message);
+            }
+            return omitNull;
         }
         return false;
     }

--- a/core/src/main/java/com/backblaze/b2/json/FieldInfo.java
+++ b/core/src/main/java/com/backblaze/b2/json/FieldInfo.java
@@ -26,13 +26,15 @@ public final class FieldInfo implements Comparable<FieldInfo> {
     public int constructorArgIndex;
     public long bit;
     public final boolean isSensitive;
+    public final boolean omitNull;
 
     /*package*/ FieldInfo(
             Field field, B2JsonTypeHandler<?> handler,
             FieldRequirement requirement,
             String defaultValueJsonOrNull,
             VersionRange versionRange,
-            boolean isSensitive
+            boolean isSensitive,
+            boolean omitNull
     ) {
         this.field = field;
         this.handler =  handler;
@@ -40,6 +42,7 @@ public final class FieldInfo implements Comparable<FieldInfo> {
         this.defaultValueJsonOrNull = defaultValueJsonOrNull;
         this.versionRange = versionRange;
         this.isSensitive = isSensitive;
+        this.omitNull = omitNull;
 
         this.field.setAccessible(true);
     }

--- a/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
+++ b/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
@@ -2147,6 +2147,16 @@ public class B2JsonTest extends B2BaseTest {
                 B2Json.toJsonOrThrowRuntime(secureContainer, options));
     }
 
+    private static class OmitNullBadTestClass {
+        @B2Json.optional(omitNull = true)
+        private final int omitNullInt;
+
+        @B2Json.constructor(params = "omitNullInt")
+        public OmitNullBadTestClass(int omitNullInt) {
+            this.omitNullInt = omitNullInt;
+        }
+    }
+
     private static class OmitNullTestClass {
         @B2Json.optional(omitNull = true)
         private final String omitNullString;
@@ -2155,23 +2165,15 @@ public class B2JsonTest extends B2BaseTest {
         private final String regularString;
 
         @B2Json.optional(omitNull = true)
-        private final int omitNullInt;
-
-        @B2Json.optional
-        private final int regularInt;
-
-        @B2Json.optional(omitNull = true)
         private final Integer omitNullInteger;
 
         @B2Json.optional
         private final Integer regularInteger;
 
-        @B2Json.constructor(params = "omitNullString, regularString, omitNullInt, regularInt, omitNullInteger, regularInteger")
-        public OmitNullTestClass(String omitNullString, String regularString, int omitNullInt, int regularInt, Integer omitNullInteger, Integer regularInteger) {
+        @B2Json.constructor(params = "omitNullString, regularString, omitNullInteger, regularInteger")
+        public OmitNullTestClass(String omitNullString, String regularString, Integer omitNullInteger, Integer regularInteger) {
             this.omitNullString = omitNullString;
             this.regularString = regularString;
-            this.omitNullInt = omitNullInt;
-            this.regularInt = regularInt;
             this.omitNullInteger = omitNullInteger;
             this.regularInteger = regularInteger;
         }
@@ -2179,13 +2181,11 @@ public class B2JsonTest extends B2BaseTest {
 
     @Test
     public void testOmitNullWithNullInputs() {
-        final OmitNullTestClass object = new OmitNullTestClass(null, null, 0, 0, null, null);
+        final OmitNullTestClass object = new OmitNullTestClass(null, null, null, null);
         final String actual = B2Json.toJsonOrThrowRuntime(object);
 
         // The omitNullString and omitNullInteger fields should not be present in the output
         assertEquals("{\n" +
-                "  \"omitNullInt\": 0,\n" +
-                "  \"regularInt\": 0,\n" +
                 "  \"regularInteger\": null,\n" +
                 "  \"regularString\": null\n" +
                 "}", actual);
@@ -2193,15 +2193,13 @@ public class B2JsonTest extends B2BaseTest {
 
     @Test
     public void testOmitNullWithNonNullInputs() {
-        final OmitNullTestClass object = new OmitNullTestClass("foo", "bar", 1, 1, 1, 1);
+        final OmitNullTestClass object = new OmitNullTestClass("foo", "bar", 1, 1);
         final String actual = B2Json.toJsonOrThrowRuntime(object);
 
         // All the fields should be in the output
         assertEquals("{\n" +
-                "  \"omitNullInt\": 1,\n" +
                 "  \"omitNullInteger\": 1,\n" +
                 "  \"omitNullString\": \"foo\",\n" +
-                "  \"regularInt\": 1,\n" +
                 "  \"regularInteger\": 1,\n" +
                 "  \"regularString\": \"bar\"\n" +
                 "}", actual);
@@ -2215,8 +2213,13 @@ public class B2JsonTest extends B2BaseTest {
         assertNull(actual.regularString);
         assertNull(actual.omitNullInteger);
         assertNull(actual.regularInteger);
-        assertEquals(0, actual.omitNullInt);
-        assertEquals(0, actual.regularInt);
+    }
+
+    @Test
+    public void testOmitNullOnPrimitive() throws B2JsonException {
+        thrown.expectMessage("Field OmitNullBadTestClass.omitNullInt declared with 'omitNull = true' but is a primitive type");
+        final OmitNullBadTestClass bad = new OmitNullBadTestClass(123);
+        B2Json.toJsonOrThrowRuntime(bad);
     }
 
     /**

--- a/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
+++ b/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
@@ -2147,6 +2147,53 @@ public class B2JsonTest extends B2BaseTest {
                 B2Json.toJsonOrThrowRuntime(secureContainer, options));
     }
 
+    private static class OmitNullTestClass {
+        @B2Json.optional(omitNull = true)
+        private final String omitNullString;
+
+        @B2Json.optional
+        private final String regularString;
+
+        @B2Json.optional(omitNull = true)
+        private final int omitNullInt;
+
+        @B2Json.optional
+        private final int regularInt;
+
+        @B2Json.constructor(params = "omitNullString, regularString, omitNullInt, regularInt")
+        public OmitNullTestClass(String omitNullString, String regularString, int omitNullInt, int regularInt) {
+            this.omitNullString = omitNullString;
+            this.regularString = regularString;
+            this.omitNullInt = omitNullInt;
+            this.regularInt = regularInt;
+        }
+    }
+
+    @Test public void testOmitNullWithNullInputs() {
+        final OmitNullTestClass object = new OmitNullTestClass(null, null, 0, 0);
+        final String actual = B2Json.toJsonOrThrowRuntime(object);
+
+        // The omitNullString field should not be present in the output
+        assertEquals("{\n" +
+                "  \"omitNullInt\": 0,\n" +
+                "  \"regularInt\": 0,\n" +
+                "  \"regularString\": null\n" +
+                "}", actual);
+    }
+
+    @Test public void testOmitNullWithNonNullInputs() {
+        final OmitNullTestClass object = new OmitNullTestClass("foo", "bar", 1, 1);
+        final String actual = B2Json.toJsonOrThrowRuntime(object);
+
+        // All the fields should be in the output
+        assertEquals("{\n" +
+                "  \"omitNullInt\": 1,\n" +
+                "  \"omitNullString\": \"foo\",\n" +
+                "  \"regularInt\": 1,\n" +
+                "  \"regularString\": \"bar\"\n" +
+                "}", actual);
+    }
+
     /**
      * Because of serialization, the object returned from B2Json will never be the same object as an
      * instantiated one.

--- a/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
+++ b/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
@@ -2160,38 +2160,63 @@ public class B2JsonTest extends B2BaseTest {
         @B2Json.optional
         private final int regularInt;
 
-        @B2Json.constructor(params = "omitNullString, regularString, omitNullInt, regularInt")
-        public OmitNullTestClass(String omitNullString, String regularString, int omitNullInt, int regularInt) {
+        @B2Json.optional(omitNull = true)
+        private final Integer omitNullInteger;
+
+        @B2Json.optional
+        private final Integer regularInteger;
+
+        @B2Json.constructor(params = "omitNullString, regularString, omitNullInt, regularInt, omitNullInteger, regularInteger")
+        public OmitNullTestClass(String omitNullString, String regularString, int omitNullInt, int regularInt, Integer omitNullInteger, Integer regularInteger) {
             this.omitNullString = omitNullString;
             this.regularString = regularString;
             this.omitNullInt = omitNullInt;
             this.regularInt = regularInt;
+            this.omitNullInteger = omitNullInteger;
+            this.regularInteger = regularInteger;
         }
     }
 
-    @Test public void testOmitNullWithNullInputs() {
-        final OmitNullTestClass object = new OmitNullTestClass(null, null, 0, 0);
+    @Test
+    public void testOmitNullWithNullInputs() {
+        final OmitNullTestClass object = new OmitNullTestClass(null, null, 0, 0, null, null);
         final String actual = B2Json.toJsonOrThrowRuntime(object);
 
-        // The omitNullString field should not be present in the output
+        // The omitNullString and omitNullInteger fields should not be present in the output
         assertEquals("{\n" +
                 "  \"omitNullInt\": 0,\n" +
                 "  \"regularInt\": 0,\n" +
+                "  \"regularInteger\": null,\n" +
                 "  \"regularString\": null\n" +
                 "}", actual);
     }
 
-    @Test public void testOmitNullWithNonNullInputs() {
-        final OmitNullTestClass object = new OmitNullTestClass("foo", "bar", 1, 1);
+    @Test
+    public void testOmitNullWithNonNullInputs() {
+        final OmitNullTestClass object = new OmitNullTestClass("foo", "bar", 1, 1, 1, 1);
         final String actual = B2Json.toJsonOrThrowRuntime(object);
 
         // All the fields should be in the output
         assertEquals("{\n" +
                 "  \"omitNullInt\": 1,\n" +
+                "  \"omitNullInteger\": 1,\n" +
                 "  \"omitNullString\": \"foo\",\n" +
                 "  \"regularInt\": 1,\n" +
+                "  \"regularInteger\": 1,\n" +
                 "  \"regularString\": \"bar\"\n" +
                 "}", actual);
+    }
+
+    @Test
+    public void testOmitNullCreateFromEmpty() {
+        final OmitNullTestClass actual = B2Json.fromJsonOrThrowRuntime("{}", OmitNullTestClass.class);
+
+        assertNull(actual.omitNullString);
+        assertNull(actual.regularString);
+        assertNull(actual.omitNullInteger);
+        assertNull(actual.regularInteger);
+        assertEquals(0, actual.omitNullInt);
+        assertEquals(0, actual.regularInt);
     }
 
     /**


### PR DESCRIPTION
Adding omitNull parameter to the @B2Json.optional annotation to not serialize fields that have a null value. This is false by default.