### PR TITLE
Adding support to B2Json for CharSequence

### DIFF
--- a/core/src/main/java/com/backblaze/b2/json/B2JsonCharSquenceHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonCharSquenceHandler.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019, Backblaze Inc. All Rights Reserved.
+ * License https://www.backblaze.com/using_b2_code.html
+ */
+
+package com.backblaze.b2.json;
+
+import java.io.IOException;
+
+/**
+ * (De)serializes CharSequence objects
+ *
+ * When deserializing, the underlying concrete type is String and thus will allocate even
+ * when the JSON input is a string.
+ */
+public class B2JsonCharSquenceHandler implements B2JsonTypeHandler<CharSequence> {
+
+    @Override
+    public Class<CharSequence> getHandledClass() {
+        return CharSequence.class;
+    }
+
+    @Override
+    public void serialize(CharSequence obj, B2JsonOptions options, B2JsonWriter out) throws IOException, B2JsonException {
+        out.writeString(obj);
+    }
+
+    @Override
+    public CharSequence deserialize(B2JsonReader in, B2JsonOptions options) throws B2JsonException, IOException {
+        return in.readString();
+    }
+
+    @Override
+    public CharSequence deserializeUrlParam(String urlValue) throws B2JsonException {
+        return urlValue;
+    }
+
+    @Override
+    public CharSequence defaultValueForOptional() {
+        return null;
+    }
+
+    @Override
+    public boolean isStringInJson() {
+        return true;
+    }
+}

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonHandlerMap.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonHandlerMap.java
@@ -94,6 +94,7 @@ public class B2JsonHandlerMap {
         map.put(double.class, new B2JsonDoubleHandler(true));
         map.put(Double.class, new B2JsonDoubleHandler(false));
         map.put(String.class, new B2JsonStringHandler());
+        map.put(CharSequence.class, new B2JsonCharSquenceHandler());
         map.put(boolean[].class, new B2JsonBooleanArrayHandler(map.get(boolean.class)));
         map.put(char[].class, new B2JsonCharArrayHandler(map.get(char.class)));
         map.put(byte[].class, new B2JsonByteArrayHandler(map.get(byte.class)));

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonWriter.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonWriter.java
@@ -80,7 +80,7 @@ public class B2JsonWriter {
         objectOrArrayEmpty = false;
     }
 
-    public void writeString(String value) throws IOException {
+    public void writeString(CharSequence value) throws IOException {
         B2Utf8Util.writeJsonString(value, out);
         objectOrArrayEmpty = false;
     }

--- a/core/src/main/java/com/backblaze/b2/util/B2Utf8Util.java
+++ b/core/src/main/java/com/backblaze/b2/util/B2Utf8Util.java
@@ -39,7 +39,7 @@ public class B2Utf8Util {
      * @throws IOException if there's a problem converting to UTF-8 or writing to out.
      *                     if an exception is thrown, out's state is undefined.
      */
-    public static void writeJsonString(String value,
+    public static void writeJsonString(CharSequence value,
                                        OutputStream out) throws IOException {
         out.write('"');
 
@@ -76,7 +76,7 @@ public class B2Utf8Util {
      * @return the currentIndex, which might've been updated (if c started a surrogate pair)
      * @throws IOException if there's trouble with surrogates or writing the output.
      */
-    private static int doCommonWrite(String value,
+    private static int doCommonWrite(CharSequence value,
                                      int currentIndex,
                                      char c,
                                      OutputStream out) throws IOException {

--- a/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
+++ b/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
@@ -2229,4 +2229,42 @@ public class B2JsonTest extends B2BaseTest {
             this.recursiveUnion = recursiveUnion;
         }
     }
+
+    private static class CharSquenceTestClass {
+        @B2Json.required
+        CharSequence sequence;
+
+        @B2Json.constructor(params = "sequence")
+        public CharSquenceTestClass(CharSequence sequence) {
+            this.sequence = sequence;
+        }
+    }
+
+    @Test
+    public void testCharSequenceSerialization() {
+        final CharSequence sequence ="foobarbaz".subSequence(3, 6);
+
+        final CharSquenceTestClass obj = new CharSquenceTestClass(sequence);
+
+        final String actual = B2Json.toJsonOrThrowRuntime(obj);
+
+        final String expected = "{\n" +
+                "  \"sequence\": \"bar\"\n" +
+                "}";
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testCharSequenceDeserialization() {
+        final String input = "{\n" +
+                "  \"sequence\": \"bar\"\n" +
+                "}";
+
+        final CharSquenceTestClass obj = B2Json.fromJsonOrThrowRuntime(input, CharSquenceTestClass.class);
+
+        assertEquals("bar", obj.sequence);
+        // the underlying implementation of CharSequence that we deserialize is String
+        assertEquals(String.class, obj.sequence.getClass());
+    }
 }


### PR DESCRIPTION
Deserialization will still create a String. It is a future area of optimization if we want to support allocation free parsing in B2Json.