### PR TITLE
B2ListFileVersionsRequest: remove overzealous assert

### DIFF
--- a/core/src/main/java/com/backblaze/b2/client/structures/B2ListFileVersionsRequest.java
+++ b/core/src/main/java/com/backblaze/b2/client/structures/B2ListFileVersionsRequest.java
@@ -121,7 +121,9 @@ public class B2ListFileVersionsRequest {
 
         public Builder setStart(String startFileName, String startFileId) {
             B2Preconditions.checkArgument(startFileName != null);
-            B2Preconditions.checkArgument(startFileId != null);
+            // when "folders" are allowed to be returned from b2_list_file_versions,
+            // sometimes we need to start queries from "folders", which have a fileName
+            // but no fileId.  this means we can't require startFileId to be null.
             this.startFileName = startFileName;
             this.startFileId = startFileId;
             return this;

--- a/core/src/test/java/com/backblaze/b2/client/B2ListFileVersionsIterableTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2ListFileVersionsIterableTest.java
@@ -21,6 +21,7 @@ import static com.backblaze.b2.client.B2TestHelpers.fileName;
 import static com.backblaze.b2.client.B2TestHelpers.makeVersion;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -41,6 +42,7 @@ public class B2ListFileVersionsIterableTest extends B2BaseTest {
 
         // the iterator should be empty.
         final Iterator<B2FileVersion> iter = new B2ListFileVersionsIterable(client, request).iterator();
+        //noinspection SimplifiableJUnitAssertion
         assertTrue(!iter.hasNext());
     }
 
@@ -58,9 +60,10 @@ public class B2ListFileVersionsIterableTest extends B2BaseTest {
         // iter should have two versions.
         final Iterator<B2FileVersion> iter = new B2ListFileVersionsIterable(client, request).iterator();
         assertTrue(iter.hasNext());
-        assertTrue(versions.get(0) == iter.next());
+        assertSame(versions.get(0), iter.next());
         assertTrue(iter.hasNext());
-        assertTrue(versions.get(1) == iter.next());
+        assertSame(versions.get(1), iter.next());
+        //noinspection SimplifiableJUnitAssertion
         assertTrue(!iter.hasNext());
     }
 
@@ -110,18 +113,20 @@ public class B2ListFileVersionsIterableTest extends B2BaseTest {
 
         // first page.
         assertTrue(iter.hasNext());
-        assertTrue(pageOneVersions.get(0) == iter.next());
+        assertSame(pageOneVersions.get(0), iter.next());
         assertTrue(iter.hasNext());
-        assertTrue(pageOneVersions.get(1) == iter.next());
+        assertSame(pageOneVersions.get(1), iter.next());
         assertTrue(iter.hasNext());
 
         // second page
+        //noinspection ConstantConditions
         assertTrue(iter.hasNext());
-        assertTrue(pageTwoVersions.get(0) == iter.next());
+        assertSame(pageTwoVersions.get(0), iter.next());
         assertTrue(iter.hasNext());
-        assertTrue(pageTwoVersions.get(1) == iter.next());
+        assertSame(pageTwoVersions.get(1), iter.next());
         assertTrue(iter.hasNext());
-        assertTrue(pageTwoVersions.get(2) == iter.next());
+        assertSame(pageTwoVersions.get(2), iter.next());
+        //noinspection SimplifiableJUnitAssertion
         assertTrue(!iter.hasNext());
     }
 
@@ -139,9 +144,10 @@ public class B2ListFileVersionsIterableTest extends B2BaseTest {
         // iter should have two versions.
         final Iterator<B2FileVersion> iter = new B2ListFileVersionsIterable(client, request).iterator();
         assertTrue(iter.hasNext());
-        assertTrue(versions.get(0) == iter.next());
+        assertSame(versions.get(0), iter.next());
         assertTrue(iter.hasNext());
-        assertTrue(versions.get(1) == iter.next());
+        assertSame(versions.get(1), iter.next());
+        //noinspection SimplifiableJUnitAssertion
         assertTrue(!iter.hasNext());
     }
 

--- a/core/src/test/java/com/backblaze/b2/client/B2ListFileVersionsIterableTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2ListFileVersionsIterableTest.java
@@ -126,6 +126,27 @@ public class B2ListFileVersionsIterableTest extends B2BaseTest {
     }
 
     @Test
+    public void testOkForNextFileIdToBeNull() throws B2Exception {
+        final B2ListFileVersionsRequest request = B2ListFileVersionsRequest
+                .builder(BUCKET_ID)
+                .build();
+
+        // when asked, return one answer with a few versions and no 'next's.
+        final List<B2FileVersion> versions = B2Collections.listOf(makeVersion(1,1), makeVersion(2, 1));
+        final B2ListFileVersionsResponse smallResponse = new B2ListFileVersionsResponse(versions, fileName(2), null);
+        when(client.listFileVersions(request)).thenReturn(smallResponse);
+
+        // iter should have two versions.
+        final Iterator<B2FileVersion> iter = new B2ListFileVersionsIterable(client, request).iterator();
+        assertTrue(iter.hasNext());
+        assertTrue(versions.get(0) == iter.next());
+        assertTrue(iter.hasNext());
+        assertTrue(versions.get(1) == iter.next());
+        assertTrue(!iter.hasNext());
+    }
+
+
+    @Test
     public void testBuilder() {
         B2ListFileVersionsRequest request = B2ListFileVersionsRequest
                 .builder(BUCKET_ID)


### PR DESCRIPTION
when "folders" are allowed to be returned from b2_list_file_versions,
sometimes we need to start queries from "folders", which have a fileName
but no fileId.  this means we can't require startFileId to be null.

thanks for hitting and reporting this, mark!  :)

i also let IDEA simplify some assertions in the corresponding test.
but in some places i prefer "assertTrue(!blah)" over "assertFalse(blah)",
especially in a long list of other assertions where it's harder to see
it's an "assertFALSE".

testing:
  * ./gradlew build javadoc writeNewPom
