### PR TITLE
Add general generics support to B2Json.

### DIFF
--- a/core/src/main/java/com/backblaze/b2/json/B2JsonBigDecimalHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonBigDecimalHandler.java
@@ -6,6 +6,7 @@
 package com.backblaze.b2.json;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.math.BigDecimal;
 
 /**
@@ -13,7 +14,7 @@ import java.math.BigDecimal;
  */
 public class B2JsonBigDecimalHandler implements B2JsonTypeHandler<BigDecimal> {
 
-    public Class<BigDecimal> getHandledClass() {
+    public Type getHandledType() {
         return BigDecimal.class;
     }
 

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonBigIntegerHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonBigIntegerHandler.java
@@ -6,6 +6,7 @@
 package com.backblaze.b2.json;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.math.BigInteger;
 
 /**
@@ -13,7 +14,7 @@ import java.math.BigInteger;
  */
 public class B2JsonBigIntegerHandler implements B2JsonTypeHandler<BigInteger> {
 
-    public Class<BigInteger> getHandledClass() {
+    public Type getHandledType() {
         return BigInteger.class;
     }
 

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonBooleanArrayHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonBooleanArrayHandler.java
@@ -18,7 +18,8 @@ public class B2JsonBooleanArrayHandler extends B2JsonNonUrlTypeHandler<boolean[]
         this.itemHandler = itemHandler;
     }
 
-    public Class<boolean[]> getHandledClass() {
+    @Override
+    public Class<boolean[]> getHandledType() {
         return boolean[].class;
     }
 

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonBooleanHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonBooleanHandler.java
@@ -6,6 +6,7 @@
 package com.backblaze.b2.json;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 
 /**
  * (De)serializes Boolean objects.
@@ -18,7 +19,7 @@ public class B2JsonBooleanHandler implements B2JsonTypeHandler<Boolean> {
         this.isPrimitive = isPrimitive;
     }
 
-    public Class<Boolean> getHandledClass() {
+    public Type getHandledType() {
         return Boolean.class;
     }
 

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonByteArrayHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonByteArrayHandler.java
@@ -6,6 +6,7 @@
 package com.backblaze.b2.json;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,7 +18,7 @@ public class B2JsonByteArrayHandler extends B2JsonNonUrlTypeHandler<byte[]> {
         this.itemHandler = itemHandler;
     }
 
-    public Class<byte[]> getHandledClass() {
+    public Type getHandledType() {
         return byte[].class;
     }
 

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonByteHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonByteHandler.java
@@ -6,6 +6,7 @@
 package com.backblaze.b2.json;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 
 /**
  * (De)serializes Byte objects.
@@ -18,7 +19,7 @@ public class B2JsonByteHandler implements B2JsonTypeHandler<Byte> {
         this.isPrimitive = isPrimitive;
     }
 
-    public Class<Byte> getHandledClass() {
+    public Type getHandledType() {
         return Byte.class;
     }
 

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonCharArrayHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonCharArrayHandler.java
@@ -6,6 +6,7 @@
 package com.backblaze.b2.json;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,7 +18,7 @@ public class B2JsonCharArrayHandler extends B2JsonNonUrlTypeHandler<char[]> {
         this.itemHandler = itemHandler;
     }
 
-    public Class<char[]> getHandledClass() {
+    public Type getHandledType() {
         return char[].class;
     }
 

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonCharSquenceHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonCharSquenceHandler.java
@@ -6,6 +6,7 @@
 package com.backblaze.b2.json;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 
 /**
  * (De)serializes CharSequence objects
@@ -16,7 +17,7 @@ import java.io.IOException;
 public class B2JsonCharSquenceHandler implements B2JsonTypeHandler<CharSequence> {
 
     @Override
-    public Class<CharSequence> getHandledClass() {
+    public Type getHandledType() {
         return CharSequence.class;
     }
 

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonCharacterHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonCharacterHandler.java
@@ -6,6 +6,7 @@
 package com.backblaze.b2.json;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 
 /**
  * (De)serializes Character objects.
@@ -18,7 +19,7 @@ public class B2JsonCharacterHandler implements B2JsonTypeHandler<Character> {
         this.isPrimitive = isPrimitive;
     }
 
-    public Class<Character> getHandledClass() {
+    public Type getHandledType() {
         return Character.class;
     }
 

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonConcurrentMapHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonConcurrentMapHandler.java
@@ -6,6 +6,7 @@
 package com.backblaze.b2.json;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -18,14 +19,16 @@ public class B2JsonConcurrentMapHandler extends B2JsonNonUrlTypeHandler<Concurre
 
     public B2JsonConcurrentMapHandler(B2JsonTypeHandler keyHandler, B2JsonTypeHandler valueHandler) throws B2JsonException {
         if (!keyHandler.isStringInJson()) {
-            throw new B2JsonException("Map key is not a string: " + keyHandler.getHandledClass());
+            throw new B2JsonException("Map key is not a string: " + keyHandler.getHandledType());
         }
         this.keyHandler = keyHandler;
         this.valueHandler = valueHandler;
     }
 
-    public Class<ConcurrentMap> getHandledClass() {
-        return ConcurrentMap.class;
+    public Type getHandledType() {
+        return new B2TypeResolver.ResolvedParameterizedType(
+                ConcurrentMap.class,
+                new Type[] {keyHandler.getHandledType(), valueHandler.getHandledType()});
     }
 
     public void serialize(ConcurrentMap obj, B2JsonOptions options, B2JsonWriter out) throws IOException, B2JsonException {

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonDoubleArrayHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonDoubleArrayHandler.java
@@ -6,6 +6,7 @@
 package com.backblaze.b2.json;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,7 +18,7 @@ public class B2JsonDoubleArrayHandler extends B2JsonNonUrlTypeHandler<double[]> 
         this.itemHandler = itemHandler;
     }
 
-    public Class<double[]> getHandledClass() {
+    public Type getHandledType() {
         return double[].class;
     }
 

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonDoubleHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonDoubleHandler.java
@@ -6,6 +6,7 @@
 package com.backblaze.b2.json;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 
 /**
  * (De)serializes Double objects.
@@ -18,7 +19,7 @@ public class B2JsonDoubleHandler implements B2JsonTypeHandler<Double> {
         this.isPrimitive = isPrimitive;
     }
 
-    public Class<Double> getHandledClass() {
+    public Type getHandledType() {
         return Double.class;
     }
 

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonDurationHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonDurationHandler.java
@@ -8,11 +8,12 @@ package com.backblaze.b2.json;
 import com.backblaze.b2.util.B2DateTimeUtil;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.time.Duration;
 
 class B2JsonDurationHandler implements B2JsonTypeHandler<Duration> {
 
-    public Class<Duration> getHandledClass() {
+    public Type getHandledType() {
         return Duration.class;
     }
 

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonEnumHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonEnumHandler.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Type;
 
 public class B2JsonEnumHandler<T> implements B2JsonTypeHandler<T> {
 
@@ -58,7 +59,7 @@ public class B2JsonEnumHandler<T> implements B2JsonTypeHandler<T> {
         return defaultForInvalid;
     }
 
-    public Class<T> getHandledClass() {
+    public Type getHandledType() {
         return enumClass;
     }
 

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonFloatArrayHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonFloatArrayHandler.java
@@ -6,6 +6,7 @@
 package com.backblaze.b2.json;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,7 +18,7 @@ public class B2JsonFloatArrayHandler extends B2JsonNonUrlTypeHandler<float[]> {
         this.itemHandler = itemHandler;
     }
 
-    public Class<float[]> getHandledClass() {
+    public Type getHandledType() {
         return float[].class;
     }
 

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonFloatHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonFloatHandler.java
@@ -6,6 +6,7 @@
 package com.backblaze.b2.json;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 
 /**
  * (De)serializes Float objects.
@@ -18,7 +19,7 @@ public class B2JsonFloatHandler implements B2JsonTypeHandler<Float> {
         this.isPrimitive = isPrimitive;
     }
 
-    public Class<Float> getHandledClass() {
+    public Type getHandledType() {
         return Float.class;
     }
 

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonHandlerMap.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonHandlerMap.java
@@ -232,10 +232,18 @@ public class B2JsonHandlerMap {
     /*package*/ synchronized <T> B2JsonTypeHandler<T> getUninitializedHandler(Type type) throws B2JsonException {
         // TODO validate the type - make sure it's resolved.
 
+        // class Item {
+        //     private int itemNumber;
+        //     private String itemName;
+        // }
         if (type instanceof Class) {
             final Class<T> clazz = (Class<T>) type;
             return getUninitializedHandlerForClass(clazz);
         }
+
+        // class Dataset {
+        //     private List<Double> measurements;
+        // }
         if (type instanceof ParameterizedType) {
             final ParameterizedType parameterizedType = (ParameterizedType) type;
             return getUninitializedHandlerForParameterizedType(parameterizedType);

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonHandlerMap.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonHandlerMap.java
@@ -229,7 +229,8 @@ public class B2JsonHandlerMap {
      * fields set by initialize() have been set.
      */
     /*package*/ synchronized <T> B2JsonTypeHandler<T> getUninitializedHandler(Type type) throws B2JsonException {
-        // TODO validate the type - make sure it's resolved.
+        // We do not need to check if the type is resolved here. That will happen as we recurse. If we come across
+        // a field that cannot be resolved, we will throw then.
 
         // Check to see if we've already done the work for this type.
         {

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonHandlerMap.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonHandlerMap.java
@@ -245,7 +245,9 @@ public class B2JsonHandlerMap {
         // }
         if (type instanceof ParameterizedType) {
             final ParameterizedType parameterizedType = (ParameterizedType) type;
-            return getUninitializedHandlerForParameterizedType(parameterizedType);
+            final B2JsonTypeHandler<T> handler = getUninitializedHandlerForParameterizedType(parameterizedType);
+            handlersAddedToMap.add(handler);
+            return handler;
         }
         throw new B2JsonException("do not know how to get handler for type " + type.getTypeName());
     }
@@ -326,6 +328,16 @@ public class B2JsonHandlerMap {
             B2JsonTypeHandler<?> keyHandler = getUninitializedHandler(keyType);
             B2JsonTypeHandler<?> valueHandler = getUninitializedHandler(valueType);
             return new B2JsonConcurrentMapHandler(keyHandler, valueHandler);
+        }
+        if (parameterizedType instanceof TypeResolver.ResolvedParameterizedType) {
+            final TypeResolver.ResolvedParameterizedType resolvedParameterizedType = (TypeResolver.ResolvedParameterizedType)parameterizedType;
+            final Type resolvedRawType = resolvedParameterizedType.getRawType();
+            if (!(resolvedRawType instanceof Class)) {
+                // Is this even possible??? -_-
+                throw new B2JsonException("do not know how to get handler for parameterized type when the rawType is not a class: " + rawType.getTypeName());
+            }
+            final Class resolvedRawTypeClass = (Class)resolvedRawType;
+            return new B2JsonObjectHandler(resolvedRawTypeClass, resolvedParameterizedType.getActualTypeArguments());
         }
 
         throw new B2JsonException("do not know how to get handler for parameterized type " + parameterizedType.getTypeName());

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonIntArrayHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonIntArrayHandler.java
@@ -6,6 +6,7 @@
 package com.backblaze.b2.json;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,7 +18,7 @@ public class B2JsonIntArrayHandler extends B2JsonNonUrlTypeHandler<int[]> {
         this.itemHandler = itemHandler;
     }
 
-    public Class<int[]> getHandledClass() {
+    public Type getHandledType() {
         return int[].class;
     }
 

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonIntegerHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonIntegerHandler.java
@@ -6,6 +6,7 @@
 package com.backblaze.b2.json;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 
 /**
  * (De)serializes Integer objects.
@@ -18,7 +19,7 @@ public class B2JsonIntegerHandler implements B2JsonTypeHandler<Integer> {
         this.isPrimitive = isPrimitive;
     }
 
-    public Class<Integer> getHandledClass() {
+    public Type getHandledType() {
         return Integer.class;
     }
 

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonLinkedHashSetHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonLinkedHashSetHandler.java
@@ -6,6 +6,7 @@
 package com.backblaze.b2.json;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.util.LinkedHashSet;
 
 public class B2JsonLinkedHashSetHandler extends B2JsonNonUrlTypeHandler<LinkedHashSet> {
@@ -15,8 +16,10 @@ public class B2JsonLinkedHashSetHandler extends B2JsonNonUrlTypeHandler<LinkedHa
         this.itemHandler = itemHandler;
     }
 
-    public Class<LinkedHashSet> getHandledClass() {
-        return LinkedHashSet.class;
+    public Type getHandledType() {
+        return new B2TypeResolver.ResolvedParameterizedType(
+                LinkedHashSet.class,
+                new Type[] {itemHandler.getHandledType()});
     }
 
     public void serialize(LinkedHashSet obj, B2JsonOptions options, B2JsonWriter out) throws IOException, B2JsonException {

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonListHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonListHandler.java
@@ -6,6 +6,7 @@
 package com.backblaze.b2.json;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -31,8 +32,10 @@ public class B2JsonListHandler extends B2JsonNonUrlTypeHandler<List> {
         this.itemHandler = itemHandler;
     }
 
-    public Class<List> getHandledClass() {
-        return List.class;
+    public Type getHandledType() {
+        return new B2TypeResolver.ResolvedParameterizedType(
+                List.class,
+                new Type[] {itemHandler.getHandledType()});
     }
 
     public void serialize(List obj, B2JsonOptions options, B2JsonWriter out) throws IOException, B2JsonException {

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonLocalDateHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonLocalDateHandler.java
@@ -9,6 +9,7 @@ import com.backblaze.b2.util.B2DateTimeUtil;
 import com.backblaze.b2.util.B2StringUtil;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.time.LocalDate;
 
 import static com.backblaze.b2.util.B2DateTimeUtil.MAX_DAY;
@@ -20,7 +21,7 @@ import static com.backblaze.b2.util.B2DateTimeUtil.MIN_YEAR;
 
 public class B2JsonLocalDateHandler implements B2JsonTypeHandler<LocalDate> {
 
-    public Class<LocalDate> getHandledClass() {
+    public Type getHandledType() {
         return LocalDate.class;
     }
 

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonLocalDateTimeHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonLocalDateTimeHandler.java
@@ -8,11 +8,12 @@ package com.backblaze.b2.json;
 import com.backblaze.b2.util.B2DateTimeUtil;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.time.LocalDateTime;
 
 public class B2JsonLocalDateTimeHandler implements B2JsonTypeHandler<LocalDateTime> {
 
-    public Class<LocalDateTime> getHandledClass() {
+    public Type getHandledType() {
         return LocalDateTime.class;
     }
 

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonLongArrayHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonLongArrayHandler.java
@@ -6,6 +6,7 @@
 package com.backblaze.b2.json;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,7 +18,7 @@ public class B2JsonLongArrayHandler extends B2JsonNonUrlTypeHandler<long[]> {
         this.itemHandler = itemHandler;
     }
 
-    public Class<long[]> getHandledClass() {
+    public Type getHandledType() {
         return long[].class;
     }
 

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonLongHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonLongHandler.java
@@ -6,6 +6,7 @@
 package com.backblaze.b2.json;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 
 /**
  * (De)serializes Long objects.
@@ -18,7 +19,7 @@ public class B2JsonLongHandler implements B2JsonTypeHandler<Long> {
         this.isPrimitive = isPrimitive;
     }
 
-    public Class<Long> getHandledClass() {
+    public Type getHandledType() {
         return Long.class;
     }
 

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonMapHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonMapHandler.java
@@ -6,6 +6,7 @@
 package com.backblaze.b2.json;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -17,14 +18,16 @@ public class B2JsonMapHandler extends B2JsonNonUrlTypeHandler<Map> {
 
     public B2JsonMapHandler(B2JsonTypeHandler keyHandler, B2JsonTypeHandler valueHandler) throws B2JsonException {
         if (!keyHandler.isStringInJson()) {
-            throw new B2JsonException("Map key is not a string: " + keyHandler.getHandledClass());
+            throw new B2JsonException("Map key is not a string: " + keyHandler.getHandledType());
         }
         this.keyHandler = keyHandler;
         this.valueHandler = valueHandler;
     }
 
-    public Class<Map> getHandledClass() {
-        return Map.class;
+    public Type getHandledType() {
+        return new B2TypeResolver.ResolvedParameterizedType(
+                Map.class,
+                new Type[] {keyHandler.getHandledType(), valueHandler.getHandledType()});
     }
 
     public void serialize(Map obj, B2JsonOptions options, B2JsonWriter out) throws IOException, B2JsonException {

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonObjectArrayHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonObjectArrayHandler.java
@@ -7,6 +7,7 @@ package com.backblaze.b2.json;
 
 import java.io.IOException;
 import java.lang.reflect.Array;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,8 +24,9 @@ public class B2JsonObjectArrayHandler<T> extends B2JsonNonUrlTypeHandler<T> {
         this.itemHandler = itemHandler;
     }
 
-    public Class<T> getHandledClass() {
-        return arrayClazz;
+    public Type getHandledType() {
+        return new B2TypeResolver.ResolvedParameterizedType(
+                arrayClazz, new Type[] {eltClazz});
     }
 
     public void serialize(T array, B2JsonOptions options, B2JsonWriter out) throws IOException, B2JsonException {

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonObjectHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonObjectHandler.java
@@ -32,7 +32,7 @@ public class B2JsonObjectHandler<T> extends B2JsonTypeHandlerWithDefaults<T> {
      * The class of object we handle.
      */
     private final Class<T> clazz;
-    private final TypeResolver typeResolver;
+    private final B2TypeResolver typeResolver;
 
     /**
      * The union class that this one belongs to, or null if there is not one.
@@ -89,7 +89,7 @@ public class B2JsonObjectHandler<T> extends B2JsonTypeHandlerWithDefaults<T> {
     /*package*/ B2JsonObjectHandler(Class<T> clazz, Type[] actualTypeArguments) throws B2JsonException {
 
         this.clazz = clazz;
-        this.typeResolver = new TypeResolver(clazz, actualTypeArguments);
+        this.typeResolver = new B2TypeResolver(clazz, actualTypeArguments);
 
         // Is this a member of a union type?
         {

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonObjectHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonObjectHandler.java
@@ -307,10 +307,6 @@ public class B2JsonObjectHandler<T> extends B2JsonTypeHandlerWithDefaults<T> {
         }
     }
 
-    public Class<T> getHandledClass() {
-        return clazz;
-    }
-
     public Type getHandledType() {
         return typeResolver.getType();
     }

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonObjectHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonObjectHandler.java
@@ -118,7 +118,6 @@ public class B2JsonObjectHandler<T> extends B2JsonTypeHandlerWithDefaults<T> {
         // Get information on all of the fields in the class.
         for (Field field : B2JsonHandlerMap.getObjectFieldsForJson(clazz)) {
             final FieldRequirement requirement = B2JsonHandlerMap.getFieldRequirement(clazz, field);
-//            final B2JsonTypeHandler<?> handler = B2JsonHandlerMap.getUninitializedFieldHandler(field.getGenericType(), handlerMap);
             final B2JsonTypeHandler<?> handler = handlerMap.getUninitializedHandler(field.getGenericType());
             final String defaultValueJsonOrNull = getDefaultValueJsonOrNull(field);
             final VersionRange versionRange = getVersionRange(field);

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonObjectHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonObjectHandler.java
@@ -125,7 +125,7 @@ public class B2JsonObjectHandler<T> extends B2JsonTypeHandlerWithDefaults<T> {
         // Get information on all of the fields in the class.
         for (Field field : B2JsonHandlerMap.getObjectFieldsForJson(clazz)) {
             final FieldRequirement requirement = B2JsonHandlerMap.getFieldRequirement(clazz, field);
-            final Type resolvedFieldType = typeResolver.resolveType(field.getGenericType());
+            final Type resolvedFieldType = typeResolver.resolveType(field);
             final B2JsonTypeHandler<?> handler = handlerMap.getUninitializedHandler(resolvedFieldType);
             final String defaultValueJsonOrNull = getDefaultValueJsonOrNull(field);
             final VersionRange versionRange = getVersionRange(field);

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonObjectHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonObjectHandler.java
@@ -118,7 +118,8 @@ public class B2JsonObjectHandler<T> extends B2JsonTypeHandlerWithDefaults<T> {
         // Get information on all of the fields in the class.
         for (Field field : B2JsonHandlerMap.getObjectFieldsForJson(clazz)) {
             final FieldRequirement requirement = B2JsonHandlerMap.getFieldRequirement(clazz, field);
-            final B2JsonTypeHandler<?> handler = B2JsonHandlerMap.getUninitializedFieldHandler(field.getGenericType(), handlerMap);
+//            final B2JsonTypeHandler<?> handler = B2JsonHandlerMap.getUninitializedFieldHandler(field.getGenericType(), handlerMap);
+            final B2JsonTypeHandler<?> handler = handlerMap.getUninitializedHandler(field.getGenericType());
             final String defaultValueJsonOrNull = getDefaultValueJsonOrNull(field);
             final VersionRange versionRange = getVersionRange(field);
             final boolean isSensitive = field.getAnnotation(B2Json.sensitive.class) != null;

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonObjectHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonObjectHandler.java
@@ -14,6 +14,7 @@ import java.io.StringReader;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -31,6 +32,7 @@ public class B2JsonObjectHandler<T> extends B2JsonTypeHandlerWithDefaults<T> {
      * The class of object we handle.
      */
     private final Class<T> clazz;
+    private final TypeResolver typeResolver;
 
     /**
      * The union class that this one belongs to, or null if there is not one.
@@ -81,8 +83,13 @@ public class B2JsonObjectHandler<T> extends B2JsonTypeHandlerWithDefaults<T> {
      * Sets up a new handler for this class based on reflection for the class.
      */
     /*package*/ B2JsonObjectHandler(Class<T> clazz) throws B2JsonException {
+        this(clazz, null);
+    }
+
+    /*package*/ B2JsonObjectHandler(Class<T> clazz, Type[] actualTypeArguments) throws B2JsonException {
 
         this.clazz = clazz;
+        this.typeResolver = new TypeResolver(clazz, actualTypeArguments);
 
         // Is this a member of a union type?
         {
@@ -118,7 +125,8 @@ public class B2JsonObjectHandler<T> extends B2JsonTypeHandlerWithDefaults<T> {
         // Get information on all of the fields in the class.
         for (Field field : B2JsonHandlerMap.getObjectFieldsForJson(clazz)) {
             final FieldRequirement requirement = B2JsonHandlerMap.getFieldRequirement(clazz, field);
-            final B2JsonTypeHandler<?> handler = handlerMap.getUninitializedHandler(field.getGenericType());
+            final Type resolvedFieldType = typeResolver.resolveType(field.getGenericType());
+            final B2JsonTypeHandler<?> handler = handlerMap.getUninitializedHandler(resolvedFieldType);
             final String defaultValueJsonOrNull = getDefaultValueJsonOrNull(field);
             final VersionRange versionRange = getVersionRange(field);
             final boolean isSensitive = field.getAnnotation(B2Json.sensitive.class) != null;
@@ -301,6 +309,10 @@ public class B2JsonObjectHandler<T> extends B2JsonTypeHandlerWithDefaults<T> {
 
     public Class<T> getHandledClass() {
         return clazz;
+    }
+
+    public Type getHandledType() {
+        return typeResolver.getType();
     }
 
     /**

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonSetHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonSetHandler.java
@@ -6,6 +6,7 @@
 package com.backblaze.b2.json;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -19,8 +20,10 @@ public class B2JsonSetHandler extends B2JsonNonUrlTypeHandler<Set> {
         this.itemHandler = itemHandler;
     }
 
-    public Class<Set> getHandledClass() {
-        return Set.class;
+    public Type getHandledType() {
+        return new B2TypeResolver.ResolvedParameterizedType(
+                Set.class,
+                new Type[]{itemHandler.getHandledType()});
     }
 
     public void serialize(Set obj, B2JsonOptions options, B2JsonWriter out) throws IOException, B2JsonException {

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonStringHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonStringHandler.java
@@ -6,13 +6,14 @@
 package com.backblaze.b2.json;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 
 /**
  * (De)serializes String objects.
  */
 public class B2JsonStringHandler implements B2JsonTypeHandler<String> {
 
-    public Class<String> getHandledClass() {
+    public Type getHandledType() {
         return String.class;
     }
 

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonTreeSetHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonTreeSetHandler.java
@@ -6,6 +6,7 @@
 package com.backblaze.b2.json;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.util.TreeSet;
 
 public class B2JsonTreeSetHandler extends B2JsonNonUrlTypeHandler<TreeSet> {
@@ -15,8 +16,10 @@ public class B2JsonTreeSetHandler extends B2JsonNonUrlTypeHandler<TreeSet> {
         this.itemHandler = itemHandler;
     }
 
-    public Class<TreeSet> getHandledClass() {
-        return TreeSet.class;
+    public Type getHandledType() {
+        return new B2TypeResolver.ResolvedParameterizedType(
+                TreeSet.class,
+                new Type[]{itemHandler.getHandledType()});
     }
 
     public void serialize(TreeSet obj, B2JsonOptions options, B2JsonWriter out) throws IOException, B2JsonException {

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonTypeHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonTypeHandler.java
@@ -15,13 +15,9 @@ public interface B2JsonTypeHandler<T> {
 
     /**
      * What class does this handle?
+     * @return
      */
-    Class<T> getHandledClass();
-
-    default Type getHandledType() {
-        // TODO delete getHandledClass()?
-        return getHandledClass();
-    }
+    Type getHandledType();
 
     /**
      * Serialize one object of the class to a JSON output stream.

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonTypeHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonTypeHandler.java
@@ -6,6 +6,7 @@
 package com.backblaze.b2.json;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 
 /**
  * Interface for (de)serializing one class of object.
@@ -16,6 +17,11 @@ public interface B2JsonTypeHandler<T> {
      * What class does this handle?
      */
     Class<T> getHandledClass();
+
+    default Type getHandledType() {
+        // TODO delete getHandledClass()?
+        return getHandledClass();
+    }
 
     /**
      * Serialize one object of the class to a JSON output stream.

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonUnionBaseHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonUnionBaseHandler.java
@@ -131,12 +131,7 @@ public class B2JsonUnionBaseHandler<T> extends B2JsonTypeHandlerWithDefaults<T> 
         for (Class<?> subclass : typeNameToClass.values()) {
             for (Field field : B2JsonHandlerMap.getObjectFieldsForJson(subclass)) {
                 final String fieldName = field.getName();
-                final B2JsonTypeHandler handler =
-//                        B2JsonHandlerMap.getUninitializedFieldHandler(
-//                                field.getGenericType(),
-//                                b2JsonHandlerMap
-//                        );
-                        b2JsonHandlerMap.getUninitializedHandler(field.getGenericType());
+                final B2JsonTypeHandler handler = b2JsonHandlerMap.getUninitializedHandler(field.getGenericType());
                 if (fieldNameToHandler.containsKey(fieldName)) {
                     // We have seen this field name before.  Throw an error if the type is different
                     // than before.

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonUnionBaseHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonUnionBaseHandler.java
@@ -15,6 +15,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -139,8 +140,8 @@ public class B2JsonUnionBaseHandler<T> extends B2JsonTypeHandlerWithDefaults<T> 
                         throw new B2JsonException(
                                 "In union type " + clazz + ", field " + fieldName + " has two different types.  " +
                                         fieldNameToSourceClassName.get(fieldName) + " has " +
-                                        fieldNameToHandler.get(fieldName).getHandledClass() + " and " +
-                                        subclass.toString() + " has " + handler.getHandledClass()
+                                        fieldNameToHandler.get(fieldName).getHandledType() + " and " +
+                                        subclass.toString() + " has " + handler.getHandledType()
                         );
                     }
                 }
@@ -239,7 +240,8 @@ public class B2JsonUnionBaseHandler<T> extends B2JsonTypeHandlerWithDefaults<T> 
     }
 
     @Override
-    public Class<T> getHandledClass() {
+    public Type getHandledType() {
+        // TODO not sure what to do here...
         return clazz;
     }
 

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonUnionBaseHandler.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonUnionBaseHandler.java
@@ -132,10 +132,11 @@ public class B2JsonUnionBaseHandler<T> extends B2JsonTypeHandlerWithDefaults<T> 
             for (Field field : B2JsonHandlerMap.getObjectFieldsForJson(subclass)) {
                 final String fieldName = field.getName();
                 final B2JsonTypeHandler handler =
-                        B2JsonHandlerMap.getUninitializedFieldHandler(
-                                field.getGenericType(),
-                                b2JsonHandlerMap
-                        );
+//                        B2JsonHandlerMap.getUninitializedFieldHandler(
+//                                field.getGenericType(),
+//                                b2JsonHandlerMap
+//                        );
+                        b2JsonHandlerMap.getUninitializedHandler(field.getGenericType());
                 if (fieldNameToHandler.containsKey(fieldName)) {
                     // We have seen this field name before.  Throw an error if the type is different
                     // than before.

--- a/core/src/main/java/com/backblaze/b2/json/B2TypeResolver.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2TypeResolver.java
@@ -38,18 +38,18 @@ import java.util.TreeMap;
  * the additional context of the type arguments used along with the Item class. This allows us to resolve the types of
  * Enclosing.class' fields.
  *
- * final TypeResolver typeResolver = new TypeResolver(Enclosing.class);
+ * final B2TypeResolver typeResolver = new B2TypeResolver(Enclosing.class);
  * // The following returns ResolvedParameterizedType(Item.class, new Type[]{ String.class });
  * typeResolver.resolveType(Enclosing.class.getDeclaredFields()[0]);
  *
  */
-public class TypeResolver {
+public class B2TypeResolver {
 
     private final Class<?> clazz;
     private final Type type;
     private final Map<String, Type> typeMap;
 
-    public TypeResolver(Class<?> clazz) {
+    public B2TypeResolver(Class<?> clazz) {
         this(clazz, null);
     }
 
@@ -62,13 +62,13 @@ public class TypeResolver {
      * If clazz is not parameterized, then the code will throw if you supply anything other than null or a 0-length
      * array for actualTypeArguments.
      */
-    public TypeResolver(Class<?> clazz, Type[] actualTypeArgumentsOrNull) {
+    public B2TypeResolver(Class<?> clazz, Type[] actualTypeArgumentsOrNull) {
         B2Preconditions.checkArgumentIsNotNull(clazz, "Supplied class must not be null");
         TypeVariable[] typeParameters = clazz.getTypeParameters();
         if (typeParameters.length == 0) {
             B2Preconditions.checkArgument(
                     actualTypeArgumentsOrNull == null || actualTypeArgumentsOrNull.length == 0,
-                    "Cannot create TypeResolver with type arguments. Class " + clazz.getName() + " has no type parameters");
+                    "Cannot create B2TypeResolver with type arguments. Class " + clazz.getName() + " has no type parameters");
         } else {
             B2Preconditions.checkArgument(
                     actualTypeArgumentsOrNull != null && typeParameters.length == actualTypeArgumentsOrNull.length,
@@ -100,7 +100,7 @@ public class TypeResolver {
     /**
      * Resolve the type of the supplied field.
      *
-     * Will throw if field does not belong to the class this TypeResolver is for.
+     * Will throw if field does not belong to the class this B2TypeResolver is for.
      */
     public Type resolveType(Field field) {
         B2Preconditions.checkArgument(

--- a/core/src/main/java/com/backblaze/b2/json/B2TypeResolver.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2TypeResolver.java
@@ -23,7 +23,7 @@ import java.util.TreeMap;
  *
  * For example, consider the following classes.
  *
- * <pre>
+ * <pre>{@code
  * class Item<T> {
  *     T value;
  *     List<T> values;
@@ -33,7 +33,7 @@ import java.util.TreeMap;
  *     Item<String> stringItem;
  *     Item<Integer> integerItem;
  * }
- * </pre>
+ * }</pre>
  *
  * When considering just Item.class, we do not have enough information to resolve the type for .value and .values.
  * However, if we are considering Enclosing.class, then even though it has fields that are Item.class instances, we have

--- a/core/src/main/java/com/backblaze/b2/json/B2TypeResolver.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2TypeResolver.java
@@ -23,6 +23,7 @@ import java.util.TreeMap;
  *
  * For example, consider the following classes.
  *
+ * <pre>
  * class Item<T> {
  *     T value;
  *     List<T> values;
@@ -32,6 +33,7 @@ import java.util.TreeMap;
  *     Item<String> stringItem;
  *     Item<Integer> integerItem;
  * }
+ * </pre>
  *
  * When considering just Item.class, we do not have enough information to resolve the type for .value and .values.
  * However, if we are considering Enclosing.class, then even though it has fields that are Item.class instances, we have

--- a/core/src/main/java/com/backblaze/b2/json/TypeResolver.java
+++ b/core/src/main/java/com/backblaze/b2/json/TypeResolver.java
@@ -53,6 +53,15 @@ public class TypeResolver {
         this(clazz, null);
     }
 
+    /**
+     * Creates a type resolver for the supplied class.
+     *
+     * If clazz is a parameterized class, then the code will throw if you do not supply the actual type arguments used
+     * with the class, or the actualTypeArguments is the wrong length for the number of type parameters clazz takes.
+     *
+     * If clazz is not parameterized, then the code will throw if you supply anything other than null or a 0-length
+     * array for actualTypeArguments.
+     */
     public TypeResolver(Class<?> clazz, Type[] actualTypeArgumentsOrNull) {
         B2Preconditions.checkArgumentIsNotNull(clazz, "Supplied class must not be null");
         TypeVariable[] typeParameters = clazz.getTypeParameters();
@@ -67,7 +76,6 @@ public class TypeResolver {
         }
 
         this.clazz = clazz;
-
         // If there are no type arguments, then this is just a concrete class.
         if (typeParameters.length == 0) {
             this.type = clazz;
@@ -81,10 +89,10 @@ public class TypeResolver {
         }
     }
 
-    public Field[] getDeclaredFields() {
-        return clazz.getDeclaredFields();
-    }
-
+    /**
+     * Returns the type this resolver is working over. That is, the class that encloses the fields this object knows
+     * how to resolve.
+     */
     public Type getType() {
         return type;
     }

--- a/core/src/main/java/com/backblaze/b2/json/TypeResolver.java
+++ b/core/src/main/java/com/backblaze/b2/json/TypeResolver.java
@@ -4,6 +4,8 @@
  */
 package com.backblaze.b2.json;
 
+import com.backblaze.b2.util.B2Preconditions;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.ParameterizedType;
@@ -55,14 +57,16 @@ public class TypeResolver {
     }
 
     public Type resolveType(Field field) {
+        B2Preconditions.checkArgument(
+                field.getDeclaringClass().equals(this.clazz),
+                "cannot resolve fields from other classes");
         return resolveType(field.getGenericType());
     }
 
-    public Type resolveType(Type type) {
+    private Type resolveType(Type type) {
         if (type instanceof Class) {
             return type;
         }
-
 
         if (type instanceof TypeVariable) {
             // If we're here, then type needs to be resolved.

--- a/core/src/main/java/com/backblaze/b2/json/TypeResolver.java
+++ b/core/src/main/java/com/backblaze/b2/json/TypeResolver.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2019, Backblaze Inc. All Rights Reserved.
+ * License https://www.backblaze.com/using_b2_code.html
+ */
+package com.backblaze.b2.json;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+
+public class TypeResolver {
+
+    private final Class<?> clazz;
+    private final Type type;
+    private final Map<String, Type> typeMap;
+
+    public TypeResolver(Class<?> clazz) {
+        this(clazz, null);
+    }
+
+    public TypeResolver(Class<?> clazz, Type[] actualTypeArguments) {
+        this.clazz = clazz;
+
+        // If there are no type arguments, then this is just a concrete class.
+        if (actualTypeArguments == null) {
+            this.type = clazz;
+            this.typeMap = null;
+        } else {
+            TypeVariable[] typeParameters = clazz.getTypeParameters();
+            if (typeParameters.length != actualTypeArguments.length) {
+                throw new RuntimeException("actualTypeArguments must be same length as class' type parameters");
+            }
+
+            this.type = new ResolvedParameterizedType(clazz, actualTypeArguments);
+            this.typeMap = new TreeMap<>();
+            for (int i = 0; i < typeParameters.length; i++) {
+                typeMap.put(typeParameters[i].getName(), actualTypeArguments[i]);
+            }
+        }
+    }
+
+    public Field[] getDeclaredFields() {
+        return clazz.getDeclaredFields();
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public Type resolveType(Field field) {
+        return resolveType(field.getGenericType());
+    }
+
+    public Type resolveType(Type type) {
+        if (type instanceof Class) {
+            return type;
+        }
+
+
+        if (type instanceof TypeVariable) {
+            // If we're here, then type needs to be resolved.
+            // If there's no typeMap, then throw, because we cannot resolve anything.
+            if (typeMap == null) {
+                throw new RuntimeException("Cannot resolve type " + type + " - the typeMap is empty");
+            }
+            return typeMap.get(type.getTypeName());
+        }
+        if (type instanceof ParameterizedType) {
+            final ParameterizedType parameterizedType = (ParameterizedType)type;
+            final Type[] resolvedActualTypeArguments = resolveTypes(parameterizedType.getActualTypeArguments());
+            // TODO can we safely assume rawType will always be a class?
+            return new ResolvedParameterizedType(parameterizedType.getRawType(), resolvedActualTypeArguments);
+        }
+        if (type instanceof GenericArrayType) {
+            final GenericArrayType genericArrayType = (GenericArrayType)type;
+            final Type resolvedComponentType = resolveType(genericArrayType.getGenericComponentType());
+            return new ResolvedGenericArrayType(resolvedComponentType);
+        }
+        if (type instanceof WildcardType) {
+            throw new RuntimeException("Wildcard types are not supported");
+        }
+        throw new RuntimeException("Do not know how to resolve type " + type.getClass());
+    }
+
+    private Type[] resolveTypes(Type[] types) {
+        final Type[] resolvedTypes = new Type[types.length];
+
+        for (int i = 0; i < types.length; i++) {
+            resolvedTypes[i] = resolveType(types[i]);
+        }
+        return resolvedTypes;
+    }
+
+    static class ResolvedGenericArrayType implements GenericArrayType {
+
+        private Type genericComponentType;
+
+        public ResolvedGenericArrayType(Type genericComponentType) {
+            this.genericComponentType = genericComponentType;
+        }
+
+        @Override
+        public Type getGenericComponentType() {
+            return genericComponentType;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ResolvedGenericArrayType that = (ResolvedGenericArrayType) o;
+            return Objects.equals(genericComponentType, that.genericComponentType);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(genericComponentType);
+        }
+    }
+
+    static class ResolvedParameterizedType implements ParameterizedType {
+
+        private final Type rawType;
+        private final Type[] actualTypeArguments;
+
+        public ResolvedParameterizedType(Type rawType, Type[] actualTypeArguments) {
+            this.rawType = rawType;
+            this.actualTypeArguments = actualTypeArguments;
+        }
+
+        @Override
+        public Type[] getActualTypeArguments() {
+            return actualTypeArguments;
+        }
+
+        @Override
+        public Type getRawType() {
+            return rawType;
+        }
+
+        @Override
+        public Type getOwnerType() {
+            // TODO implement (if needed)?
+            throw new RuntimeException("this shouldn't be called");
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ResolvedParameterizedType that = (ResolvedParameterizedType) o;
+            return Objects.equals(rawType, that.rawType) &&
+                    Arrays.equals(actualTypeArguments, that.actualTypeArguments);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(rawType, actualTypeArguments);
+        }
+    }
+}

--- a/core/src/main/java/com/backblaze/b2/json/TypeResolver.java
+++ b/core/src/main/java/com/backblaze/b2/json/TypeResolver.java
@@ -79,7 +79,7 @@ public class TypeResolver {
             // If we're here, then type needs to be resolved.
             // If there's no typeMap, then throw, because we cannot resolve anything.
             final String typeName = type.getTypeName();
-            B2Preconditions.checkState(type != null && typeMap.containsKey(typeName));
+            B2Preconditions.checkState(typeMap.containsKey(typeName));
             return typeMap.get(typeName);
         }
         if (type instanceof ParameterizedType) {
@@ -172,7 +172,9 @@ public class TypeResolver {
 
         @Override
         public int hashCode() {
-            return Objects.hash(rawType, actualTypeArguments);
+            int result = Objects.hash(rawType);
+            result = 31 * result + Arrays.hashCode(actualTypeArguments);
+            return result;
         }
     }
 }

--- a/core/src/test/java/com/backblaze/b2/json/B2JsonHandlerMapTest.java
+++ b/core/src/test/java/com/backblaze/b2/json/B2JsonHandlerMapTest.java
@@ -72,7 +72,7 @@ public class B2JsonHandlerMapTest extends B2BaseTest {
     public void testSet() throws B2JsonException {
         final B2JsonHandlerMap handlerMap = new B2JsonHandlerMap();
 
-        thrown.expectMessage("java.util.HashSet.map should have exactly one annotation");
+        thrown.expectMessage("actualTypeArguments must be same length as class' type parameters");
         handlerMap.getHandler(HashSet.class);
     }
 

--- a/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
+++ b/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
@@ -2458,4 +2458,81 @@ public class B2JsonTest extends B2BaseTest {
 
         assertEquals(original, derived);
     }
+
+    @Test
+    public void testGenerics() throws B2JsonException {
+        final ClassThatUsesGenerics classThatUsesGenerics = new ClassThatUsesGenerics(
+                999,
+                new Item<>("the string"),
+                new Item<>(123),
+                new Item<>(new Item<>(456L))
+        );
+
+        final String expected = "{\n" +
+                "  \"id\": 999,\n" +
+                "  \"integerItem\": {\n" +
+                "    \"value\": 123\n" +
+                "  },\n" +
+                "  \"longItemItem\": {\n" +
+                "    \"value\": {\n" +
+                "      \"value\": 456\n" +
+                "    }\n" +
+                "  },\n" +
+                "  \"stringItem\": {\n" +
+                "    \"value\": \"the string\"\n" +
+                "  }\n" +
+                "}";
+        assertEquals(expected, b2Json.toJson(classThatUsesGenerics));
+
+        final ClassThatUsesGenerics classThatUsesGenericsFromJson = b2Json.fromJson(expected, ClassThatUsesGenerics.class);
+
+        assertEquals(999, classThatUsesGenericsFromJson.id);
+        assertEquals("the string", classThatUsesGenericsFromJson.stringItem.value);
+        assertEquals(new Long(456), classThatUsesGenericsFromJson.longItemItem.value.value);
+        assertEquals(new Integer(123), classThatUsesGenericsFromJson.integerItem.value);
+
+    }
+
+    private static class ClassThatUsesGenerics {
+
+        @B2Json.required
+        private int id;
+
+        @B2Json.required
+        private final Item<String> stringItem;
+
+        @B2Json.required
+        private final Item<Integer> integerItem;
+
+        @B2Json.required
+        private final Item<Item<Long>> longItemItem;
+
+        @B2Json.constructor(params = "id, stringItem, integerItem, longItemItem")
+        public ClassThatUsesGenerics(
+                int id,
+                Item<String> stringItem,
+                Item<Integer> integerItem,
+                Item<Item<Long>> longItemItem) {
+
+            this.id = id;
+            this.stringItem = stringItem;
+            this.integerItem = integerItem;
+            this.longItemItem = longItemItem;
+        }
+    }
+
+    private static class Item<T> {
+
+        @B2Json.required
+        private final T value;
+
+        @B2Json.constructor(params = "value")
+        public Item(T value) {
+            this.value = value;
+        }
+
+        public T getValue() {
+            return value;
+        }
+    }
 }

--- a/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
+++ b/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
@@ -15,6 +15,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Duration;
@@ -1224,7 +1225,7 @@ public class B2JsonTest extends B2BaseTest {
         }
 
         private static class JsonHandler implements B2JsonTypeHandler<GoodCustomHandler> {
-            public Class<GoodCustomHandler> getHandledClass() {
+            public Type getHandledType() {
                 return GoodCustomHandler.class;
             }
 
@@ -1484,7 +1485,7 @@ public class B2JsonTest extends B2BaseTest {
 
         public static class JsonHandler implements B2JsonTypeHandler<Letter> {
             @Override
-            public Class<Letter> getHandledClass() {
+            public Type getHandledType() {
                 return Letter.class;
             }
 

--- a/core/src/test/java/com/backblaze/b2/json/B2TypeResolverTest.java
+++ b/core/src/test/java/com/backblaze/b2/json/B2TypeResolverTest.java
@@ -19,14 +19,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-public class TypeResolverTest {
+public class B2TypeResolverTest {
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
-    private final TypeResolver resolverWithoutTypeArguments = new TypeResolver(TestClassWithoutTypeArguments.class);
+    private final B2TypeResolver resolverWithoutTypeArguments = new B2TypeResolver(TestClassWithoutTypeArguments.class);
     private final Field[] declaredFieldsWithoutTypeArguments = TestClassWithoutTypeArguments.class.getDeclaredFields();
-    private final TypeResolver resolverWithTypeArguments = new TypeResolver(
+    private final B2TypeResolver resolverWithTypeArguments = new B2TypeResolver(
             TestClassWithTypeArguments.class,
             new Type[]{String.class, Integer.class});
     private final Field[] declaredFieldsWithTypeArguments = TestClassWithTypeArguments.class.getDeclaredFields();
@@ -48,7 +48,7 @@ public class TypeResolverTest {
 
         {
             final Type resolvedType = resolverWithTypeArguments.getType();
-            assertTrue(resolvedType instanceof TypeResolver.ResolvedParameterizedType);
+            assertTrue(resolvedType instanceof B2TypeResolver.ResolvedParameterizedType);
             final ParameterizedType resolvedParameterizedType = (ParameterizedType) resolvedType;
             assertEquals(TestClassWithTypeArguments.class, resolvedParameterizedType.getRawType());
             assertArrayEquals(
@@ -61,7 +61,7 @@ public class TypeResolverTest {
     public void testConstructTypeResolverWithoutTypeArguments_throws() {
         thrown.expect(RuntimeException.class);
         thrown.expectMessage("actualTypeArguments must be same length as class' type parameters");
-        new TypeResolver(TestClassWithTypeArguments.class);
+        new B2TypeResolver(TestClassWithTypeArguments.class);
     }
 
     @Test
@@ -101,7 +101,7 @@ public class TypeResolverTest {
         assertEquals(OneParameterizedType.class, resolvedParameterizedType.getRawType());
         assertArrayEquals(
                 new Type[]{
-                        new TypeResolver.ResolvedParameterizedType(
+                        new B2TypeResolver.ResolvedParameterizedType(
                                 TwoParameterizedTypes.class,
                                 new Type[]{Integer.class, String.class}
                         )
@@ -109,8 +109,8 @@ public class TypeResolverTest {
 
         final Type[] resolvedActualTypeArguments = resolvedParameterizedType.getActualTypeArguments();
         assertEquals(1, resolvedActualTypeArguments.length);
-        assertTrue(resolvedActualTypeArguments[0] instanceof TypeResolver.ResolvedParameterizedType);
-        final TypeResolver.ResolvedParameterizedType resolvedParameterizedType_nested = (TypeResolver.ResolvedParameterizedType) resolvedActualTypeArguments[0];
+        assertTrue(resolvedActualTypeArguments[0] instanceof B2TypeResolver.ResolvedParameterizedType);
+        final B2TypeResolver.ResolvedParameterizedType resolvedParameterizedType_nested = (B2TypeResolver.ResolvedParameterizedType) resolvedActualTypeArguments[0];
         assertEquals(TwoParameterizedTypes.class, resolvedParameterizedType_nested.getRawType());
         assertArrayEquals(new Type[]{Integer.class, String.class}, resolvedParameterizedType_nested.getActualTypeArguments());
     }
@@ -129,7 +129,7 @@ public class TypeResolverTest {
         assertTrue(resolvedType instanceof GenericArrayType);
         final GenericArrayType resolvedGenericArrayType = (GenericArrayType) resolvedType;
         assertEquals(
-                new TypeResolver.ResolvedParameterizedType(
+                new B2TypeResolver.ResolvedParameterizedType(
                         OneParameterizedType.class,
                         new Type[]{Integer.class}
                 ),
@@ -138,7 +138,7 @@ public class TypeResolverTest {
 
     @Test
     public void testRecursiveGenericClass() {
-        final TypeResolver resolveWithRecursiveGenericClass = new TypeResolver(
+        final B2TypeResolver resolveWithRecursiveGenericClass = new B2TypeResolver(
                 RecursiveClass.class,
                 new Type[]{String.class});
 
@@ -149,7 +149,7 @@ public class TypeResolverTest {
         final Type resolvedField1 = resolveWithRecursiveGenericClass.resolveType(
                 RecursiveClass.class.getDeclaredFields()[1]);
         assertEquals(
-                new TypeResolver.ResolvedParameterizedType(
+                new B2TypeResolver.ResolvedParameterizedType(
                         RecursiveClass.class,
                         new Type[]{String.class}
                 ), resolvedField1);
@@ -157,7 +157,7 @@ public class TypeResolverTest {
 
     @Test
     public void testWildcardTypesNotSupported() {
-        final TypeResolver resolverWithWildcards = new TypeResolver(
+        final B2TypeResolver resolverWithWildcards = new B2TypeResolver(
                 EnclosingWithWildcards.class,
                 new Type[]{String.class});
 
@@ -170,7 +170,7 @@ public class TypeResolverTest {
     public void testActualTypeArgumentsWrongLength_throws() {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("actualTypeArguments must be same length as class' type parameters");
-        new TypeResolver(TestClassWithTypeArguments.class, new Type[]{});
+        new B2TypeResolver(TestClassWithTypeArguments.class, new Type[]{});
     }
 
     @Test
@@ -182,14 +182,14 @@ public class TypeResolverTest {
 
     @Test
     public void testResolvedTypeEquality() {
-        final TypeResolver.ResolvedParameterizedType resolvedParameterizedType =
-                new TypeResolver.ResolvedParameterizedType(OneParameterizedType.class, new Type[]{Integer.class});
-        final TypeResolver.ResolvedParameterizedType resolvedParameterizedTypeEqual =
-                new TypeResolver.ResolvedParameterizedType(OneParameterizedType.class, new Type[]{Integer.class});
-        final TypeResolver.ResolvedParameterizedType resolvedParameterizedTypeNotEqual1 =
-                new TypeResolver.ResolvedParameterizedType(OneParameterizedType.class, new Type[]{String.class});
-        final TypeResolver.ResolvedParameterizedType resolvedParameterizedTypeNotEqual2 =
-                new TypeResolver.ResolvedParameterizedType(List.class, new Type[]{Integer.class});
+        final B2TypeResolver.ResolvedParameterizedType resolvedParameterizedType =
+                new B2TypeResolver.ResolvedParameterizedType(OneParameterizedType.class, new Type[]{Integer.class});
+        final B2TypeResolver.ResolvedParameterizedType resolvedParameterizedTypeEqual =
+                new B2TypeResolver.ResolvedParameterizedType(OneParameterizedType.class, new Type[]{Integer.class});
+        final B2TypeResolver.ResolvedParameterizedType resolvedParameterizedTypeNotEqual1 =
+                new B2TypeResolver.ResolvedParameterizedType(OneParameterizedType.class, new Type[]{String.class});
+        final B2TypeResolver.ResolvedParameterizedType resolvedParameterizedTypeNotEqual2 =
+                new B2TypeResolver.ResolvedParameterizedType(List.class, new Type[]{Integer.class});
 
         assertEquals(resolvedParameterizedType, resolvedParameterizedTypeEqual);
         assertEquals(resolvedParameterizedType.hashCode(), resolvedParameterizedTypeEqual.hashCode());
@@ -200,12 +200,12 @@ public class TypeResolverTest {
         assertNotEquals(resolvedParameterizedType, resolvedParameterizedTypeNotEqual2);
         assertNotEquals(resolvedParameterizedType.hashCode(), resolvedParameterizedTypeNotEqual2.hashCode());
 
-        final TypeResolver.ResolvedGenericArrayType resolvedGenericArrayType =
-                new TypeResolver.ResolvedGenericArrayType(String.class);
-        final TypeResolver.ResolvedGenericArrayType resolvedGenericArrayTypeEqual =
-                new TypeResolver.ResolvedGenericArrayType(String.class);
-        final TypeResolver.ResolvedGenericArrayType resolvedGenericArrayTypeNotEqual =
-                new TypeResolver.ResolvedGenericArrayType(Integer.class);
+        final B2TypeResolver.ResolvedGenericArrayType resolvedGenericArrayType =
+                new B2TypeResolver.ResolvedGenericArrayType(String.class);
+        final B2TypeResolver.ResolvedGenericArrayType resolvedGenericArrayTypeEqual =
+                new B2TypeResolver.ResolvedGenericArrayType(String.class);
+        final B2TypeResolver.ResolvedGenericArrayType resolvedGenericArrayTypeNotEqual =
+                new B2TypeResolver.ResolvedGenericArrayType(Integer.class);
 
         assertEquals(resolvedGenericArrayType, resolvedGenericArrayTypeEqual);
         assertEquals(resolvedGenericArrayType.hashCode(), resolvedGenericArrayTypeEqual.hashCode());

--- a/core/src/test/java/com/backblaze/b2/json/TypeResolverTest.java
+++ b/core/src/test/java/com/backblaze/b2/json/TypeResolverTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2019, Backblaze Inc. All Rights Reserved.
+ * License https://www.backblaze.com/using_b2_code.html
+ */
+package com.backblaze.b2.json;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TypeResolverTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private final TypeResolver resolverWithoutActualTypes = new TypeResolver(TestClass.class);
+    private final TypeResolver resolverWithActualTypes = new TypeResolver(
+            TestClass.class,
+            new Type[]{String.class, Integer.class});
+    private final Field[] declaredFields = TestClass.class.getDeclaredFields();
+
+
+    @Test
+    public void testNoActualTypeArguments_resolvePrimitives() {
+        // Make sure we can still resolve concrete primitives, they don't have any type parameters.
+        assertEquals(int.class, resolverWithoutActualTypes.resolveType(declaredFields[0].getGenericType()));
+        assertEquals(int.class, resolverWithoutActualTypes.resolveType(declaredFields[0]));
+    }
+
+    @Test
+    public void testNoActualTypeArguments_cannotResolveParameterizedTypes() {
+        thrown.expect(RuntimeException.class);
+        thrown.expectMessage("Cannot resolve type");
+        resolverWithoutActualTypes.resolveType(declaredFields[1]);
+    }
+
+    @Test
+    public void testActualTypeArguments_resolvePrimitives() {
+        assertEquals(int.class, resolverWithActualTypes.resolveType(declaredFields[0].getGenericType()));
+        assertEquals(int.class, resolverWithActualTypes.resolveType(declaredFields[0]));
+    }
+
+    @Test
+    public void testActualTypeArguments_resolveTypeVariables() {
+        assertEquals(String.class, resolverWithActualTypes.resolveType(declaredFields[1].getGenericType()));
+        assertEquals(String.class, resolverWithActualTypes.resolveType(declaredFields[1]));
+
+        assertEquals(Integer.class, resolverWithActualTypes.resolveType(declaredFields[2].getGenericType()));
+        assertEquals(Integer.class, resolverWithActualTypes.resolveType(declaredFields[2]));
+    }
+
+    @Test
+    public void testActualTypeArguments_resolveParameterizedType_oneType() {
+        final Type resolvedType = resolverWithActualTypes.resolveType(declaredFields[3]);
+        assertTrue(resolvedType instanceof ParameterizedType);
+        final ParameterizedType resolvedParameterizedType = (ParameterizedType) resolvedType;
+        assertEquals(OneParameterizedType.class, resolvedParameterizedType.getRawType());
+        assertArrayEquals(new Type[]{String.class}, resolvedParameterizedType.getActualTypeArguments());
+    }
+
+    @Test
+    public void testActualTypeArguments_resolveParameterizedType_twoTypes() {
+        final Type resolvedType = resolverWithActualTypes.resolveType(declaredFields[4]);
+        assertTrue(resolvedType instanceof ParameterizedType);
+        final ParameterizedType resolvedParameterizedType = (ParameterizedType) resolvedType;
+        assertEquals(TwoParameterizedTypes.class, resolvedParameterizedType.getRawType());
+        assertArrayEquals(new Type[]{String.class, Integer.class}, resolvedParameterizedType.getActualTypeArguments());
+    }
+
+    @Test
+    public void testActualTypeArguments_resolveParameterizedType_nestedParameterizedTypes() {
+        final Type resolvedType = resolverWithActualTypes.resolveType(declaredFields[5]);
+        assertTrue(resolvedType instanceof ParameterizedType);
+        final ParameterizedType resolvedParameterizedType = (ParameterizedType) resolvedType;
+        assertEquals(OneParameterizedType.class, resolvedParameterizedType.getRawType());
+        assertArrayEquals(
+                new Type[]{
+                        new TypeResolver.ResolvedParameterizedType(
+                                TwoParameterizedTypes.class,
+                                new Type[]{Integer.class, String.class}
+                        )
+                }, resolvedParameterizedType.getActualTypeArguments());
+
+        final Type[] resolvedActualTypeArguments = resolvedParameterizedType.getActualTypeArguments();
+        assertEquals(1, resolvedActualTypeArguments.length);
+        assertTrue(resolvedActualTypeArguments[0] instanceof TypeResolver.ResolvedParameterizedType);
+        final TypeResolver.ResolvedParameterizedType resolvedParameterizedType_nested = (TypeResolver.ResolvedParameterizedType) resolvedActualTypeArguments[0];
+        assertEquals(TwoParameterizedTypes.class, resolvedParameterizedType_nested.getRawType());
+        assertArrayEquals(new Type[]{Integer.class, String.class}, resolvedParameterizedType_nested.getActualTypeArguments());
+    }
+
+    @Test
+    public void testActualTypeTypeArguments_array() {
+        final Type resolvedType = resolverWithActualTypes.resolveType(declaredFields[6]);
+        assertTrue(resolvedType instanceof GenericArrayType);
+        final GenericArrayType resolvedGenericArrayType = (GenericArrayType) resolvedType;
+        assertEquals(String.class, resolvedGenericArrayType.getGenericComponentType());
+    }
+
+    @Test
+    public void testActualTypeTypeArguments_arrayOfNestedTypes() {
+        final Type resolvedType = resolverWithActualTypes.resolveType(declaredFields[7]);
+        assertTrue(resolvedType instanceof GenericArrayType);
+        final GenericArrayType resolvedGenericArrayType = (GenericArrayType) resolvedType;
+        assertEquals(
+                new TypeResolver.ResolvedParameterizedType(
+                        OneParameterizedType.class,
+                        new Type[] {Integer.class}
+                ),
+                resolvedGenericArrayType.getGenericComponentType());
+    }
+
+    @Test
+    public void testRecursiveGenericClass() {
+        final TypeResolver resolveWithRecursiveGenericClass = new TypeResolver(
+                RecursiveClass.class,
+                new Type[]{String.class});
+
+        final Type resolvedField0 = resolveWithRecursiveGenericClass.resolveType(
+                resolveWithRecursiveGenericClass.getDeclaredFields()[0]);
+        assertEquals(String.class, resolvedField0);
+
+        final Type resolvedField1 = resolveWithRecursiveGenericClass.resolveType(
+                resolveWithRecursiveGenericClass.getDeclaredFields()[1]);
+        assertEquals(
+                new TypeResolver.ResolvedParameterizedType(
+                        RecursiveClass.class,
+                        new Type[]{String.class}
+                ), resolvedField1);
+    }
+
+    @Test
+    public void testWildcardTypesNotSupported() {
+        final TypeResolver resolverWithWildcards = new TypeResolver(
+                EnclosingWithWildcards.class,
+                new Type[]{String.class});
+
+        thrown.expect(RuntimeException.class);
+        thrown.expectMessage("Wildcard types are not supported");
+        resolverWithActualTypes.resolveType(resolverWithWildcards.getDeclaredFields()[0]);
+    }
+
+    // Class definitions below.
+
+    private static class TestClass<T, U> {
+        private int intType;
+        private T tType;
+        private U uType;
+        private OneParameterizedType<T> nestedTType;
+        private TwoParameterizedTypes<T, U> nestedTUTypes;
+        private OneParameterizedType<TwoParameterizedTypes<U, T>> doubleNestedTypes;
+        private T[] tArray;
+        private OneParameterizedType<U>[] arrayOfNestedUTypes;
+    }
+
+    private static class OneParameterizedType<C> {
+        private C value;
+    }
+
+    private static class TwoParameterizedTypes<A, B> {
+        private A value1;
+        private B value2;
+    }
+
+    private static class RecursiveClass<T> {
+        private T data;
+        private RecursiveClass<T> next;
+    }
+
+    private static class EnclosingWithWildcards<T> {
+        private List<? extends T> listWithWildcards;
+    }
+
+}

--- a/core/src/test/java/com/backblaze/b2/json/TypeResolverTest.java
+++ b/core/src/test/java/com/backblaze/b2/json/TypeResolverTest.java
@@ -143,11 +143,11 @@ public class TypeResolverTest {
                 new Type[]{String.class});
 
         final Type resolvedField0 = resolveWithRecursiveGenericClass.resolveType(
-                resolveWithRecursiveGenericClass.getDeclaredFields()[0]);
+                RecursiveClass.class.getDeclaredFields()[0]);
         assertEquals(String.class, resolvedField0);
 
         final Type resolvedField1 = resolveWithRecursiveGenericClass.resolveType(
-                resolveWithRecursiveGenericClass.getDeclaredFields()[1]);
+                RecursiveClass.class.getDeclaredFields()[1]);
         assertEquals(
                 new TypeResolver.ResolvedParameterizedType(
                         RecursiveClass.class,
@@ -163,7 +163,7 @@ public class TypeResolverTest {
 
         thrown.expect(RuntimeException.class);
         thrown.expectMessage("Wildcard types are not supported");
-        resolverWithWildcards.resolveType(resolverWithWildcards.getDeclaredFields()[0]);
+        resolverWithWildcards.resolveType(EnclosingWithWildcards.class.getDeclaredFields()[0]);
     }
 
     @Test

--- a/core/src/test/java/com/backblaze/b2/json/TypeResolverTest.java
+++ b/core/src/test/java/com/backblaze/b2/json/TypeResolverTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 public class TypeResolverTest {
@@ -51,7 +52,7 @@ public class TypeResolverTest {
             final ParameterizedType resolvedParameterizedType = (ParameterizedType) resolvedType;
             assertEquals(TestClassWithTypeArguments.class, resolvedParameterizedType.getRawType());
             assertArrayEquals(
-                    new Type[] {String.class, Integer.class},
+                    new Type[]{String.class, Integer.class},
                     resolvedParameterizedType.getActualTypeArguments());
         }
     }
@@ -130,7 +131,7 @@ public class TypeResolverTest {
         assertEquals(
                 new TypeResolver.ResolvedParameterizedType(
                         OneParameterizedType.class,
-                        new Type[] {Integer.class}
+                        new Type[]{Integer.class}
                 ),
                 resolvedGenericArrayType.getGenericComponentType());
     }
@@ -173,15 +174,44 @@ public class TypeResolverTest {
     }
 
     @Test
-    public void testResolveFieldOnClassWithNoTypeArgument_throws() {
-
-    }
-
-    @Test
     public void testResolveFieldFromDifferentClass_throws() {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("cannot resolve fields from other classes");
         resolverWithTypeArguments.resolveType(EnclosingWithWildcards.class.getDeclaredFields()[0]);
+    }
+
+    @Test
+    public void testResolvedTypeEquality() {
+        final TypeResolver.ResolvedParameterizedType resolvedParameterizedType =
+                new TypeResolver.ResolvedParameterizedType(OneParameterizedType.class, new Type[]{Integer.class});
+        final TypeResolver.ResolvedParameterizedType resolvedParameterizedTypeEqual =
+                new TypeResolver.ResolvedParameterizedType(OneParameterizedType.class, new Type[]{Integer.class});
+        final TypeResolver.ResolvedParameterizedType resolvedParameterizedTypeNotEqual1 =
+                new TypeResolver.ResolvedParameterizedType(OneParameterizedType.class, new Type[]{String.class});
+        final TypeResolver.ResolvedParameterizedType resolvedParameterizedTypeNotEqual2 =
+                new TypeResolver.ResolvedParameterizedType(List.class, new Type[]{Integer.class});
+
+        assertEquals(resolvedParameterizedType, resolvedParameterizedTypeEqual);
+        assertEquals(resolvedParameterizedType.hashCode(), resolvedParameterizedTypeEqual.hashCode());
+
+        assertNotEquals(resolvedParameterizedType, resolvedParameterizedTypeNotEqual1);
+        assertNotEquals(resolvedParameterizedType.hashCode(), resolvedParameterizedTypeNotEqual1.hashCode());
+
+        assertNotEquals(resolvedParameterizedType, resolvedParameterizedTypeNotEqual2);
+        assertNotEquals(resolvedParameterizedType.hashCode(), resolvedParameterizedTypeNotEqual2.hashCode());
+
+        final TypeResolver.ResolvedGenericArrayType resolvedGenericArrayType =
+                new TypeResolver.ResolvedGenericArrayType(String.class);
+        final TypeResolver.ResolvedGenericArrayType resolvedGenericArrayTypeEqual =
+                new TypeResolver.ResolvedGenericArrayType(String.class);
+        final TypeResolver.ResolvedGenericArrayType resolvedGenericArrayTypeNotEqual =
+                new TypeResolver.ResolvedGenericArrayType(Integer.class);
+
+        assertEquals(resolvedGenericArrayType, resolvedGenericArrayTypeEqual);
+        assertEquals(resolvedGenericArrayType.hashCode(), resolvedGenericArrayTypeEqual.hashCode());
+
+        assertNotEquals(resolvedGenericArrayType, resolvedGenericArrayTypeNotEqual);
+        assertNotEquals(resolvedGenericArrayType.hashCode(), resolvedGenericArrayTypeNotEqual.hashCode());
     }
 
     // Class definitions below.

--- a/core/src/test/java/com/backblaze/b2/json/TypeResolverTest.java
+++ b/core/src/test/java/com/backblaze/b2/json/TypeResolverTest.java
@@ -33,7 +33,6 @@ public class TypeResolverTest {
     @Test
     public void testNoActualTypeArguments_resolvePrimitives() {
         // Make sure we can still resolve concrete primitives, they don't have any type parameters.
-        assertEquals(int.class, resolverWithoutActualTypes.resolveType(declaredFields[0].getGenericType()));
         assertEquals(int.class, resolverWithoutActualTypes.resolveType(declaredFields[0]));
     }
 
@@ -46,16 +45,12 @@ public class TypeResolverTest {
 
     @Test
     public void testActualTypeArguments_resolvePrimitives() {
-        assertEquals(int.class, resolverWithActualTypes.resolveType(declaredFields[0].getGenericType()));
         assertEquals(int.class, resolverWithActualTypes.resolveType(declaredFields[0]));
     }
 
     @Test
     public void testActualTypeArguments_resolveTypeVariables() {
-        assertEquals(String.class, resolverWithActualTypes.resolveType(declaredFields[1].getGenericType()));
         assertEquals(String.class, resolverWithActualTypes.resolveType(declaredFields[1]));
-
-        assertEquals(Integer.class, resolverWithActualTypes.resolveType(declaredFields[2].getGenericType()));
         assertEquals(Integer.class, resolverWithActualTypes.resolveType(declaredFields[2]));
     }
 
@@ -147,7 +142,14 @@ public class TypeResolverTest {
 
         thrown.expect(RuntimeException.class);
         thrown.expectMessage("Wildcard types are not supported");
-        resolverWithActualTypes.resolveType(resolverWithWildcards.getDeclaredFields()[0]);
+        resolverWithWildcards.resolveType(resolverWithWildcards.getDeclaredFields()[0]);
+    }
+
+    @Test
+    public void testFieldFromDifferentClass_throws() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("cannot resolve fields from other classes");
+        resolverWithActualTypes.resolveType(EnclosingWithWildcards.class.getDeclaredFields()[0]);
     }
 
     // Class definitions below.


### PR DESCRIPTION
This PR adds support for (de)serialization of class hierarchies that contain generics. As long as the root class provides all the context necessary, we should be able to resolve any nested types by propagating type parameters down.

This changes the mapping from class -> handler to type -> handler. The recursion is more streamlined (no more `static` `getUnitializedFieldHandler()` method). If handlers are tied to parameteric types, they are cached by class and type arguments to avoid collisions.

This PR is broken in many many small PRs, so it can be reviewed in small steps as well as by just comparing straight to master. Hopefully that is helpful. The unit tests pass at each intermediate commit.