### PR TITLE
Extend B2FileVersion and B2Part to include contentMd5.

### DIFF
--- a/check_code
+++ b/check_code
@@ -37,7 +37,7 @@ IN_LIB_RE = re.compile("/lib/[^/]+$")
 #
 ########################
 
-COPYRIGHT_RE = re.compile("Copyright 201[0-9], Backblaze Inc. All Rights Reserved.")
+COPYRIGHT_RE = re.compile("Copyright 20[12][0-9], Backblaze Inc. All Rights Reserved.")
 LICENSE_RE = re.compile("License https://www.backblaze.com/using_b2_code.html")
 
 # how many lines at the top of a file should we look at?

--- a/core/src/main/java/com/backblaze/b2/client/B2StorageClientWebifierImpl.java
+++ b/core/src/main/java/com/backblaze/b2/client/B2StorageClientWebifierImpl.java
@@ -497,6 +497,7 @@ public class B2StorageClientWebifierImpl implements B2StorageClientWebifier {
                 headers.getContentLength(),
                 headers.getContentType(),
                 headers.getContentSha1OrNull(),    // might be null.
+                headers.getContentMd5OrNull(),    // might be null.
                 headers.getB2FileInfo(),           // might be empty.
                 "upload",
                 headers.getUploadTimestampOrNull()

--- a/core/src/main/java/com/backblaze/b2/client/contentSources/B2Headers.java
+++ b/core/src/main/java/com/backblaze/b2/client/contentSources/B2Headers.java
@@ -148,7 +148,7 @@ public interface B2Headers {
     }
 
     /**
-     * @return the value of the X-Bz-Content-Sha1 header, or null if none.
+     * @return the value of the Content-MD5 header, or null if none.
      * @apiNote We return null here instead of throwing an exception since this is a
      *          an optional header in B2.  Older files will not have it.
      */

--- a/core/src/main/java/com/backblaze/b2/client/contentSources/B2Headers.java
+++ b/core/src/main/java/com/backblaze/b2/client/contentSources/B2Headers.java
@@ -49,6 +49,7 @@ public interface B2Headers {
     // some standard headers
     String AUTHORIZATION = "Authorization";
     String CONTENT_LENGTH = "Content-Length";
+    String CONTENT_MD5 = "Content-MD5";
     String CONTENT_TYPE = "Content-Type";
     String RANGE = "Range";                  // for range requests.
     String CONTENT_RANGE = "Content-Range";  // for range responses.
@@ -144,6 +145,15 @@ public interface B2Headers {
      */
     default String getContentSha1OrNull() {
         return getValueOrNull(CONTENT_SHA1);
+    }
+
+    /**
+     * @return the value of the X-Bz-Content-Sha1 header, or null if none.
+     * @apiNote We return null here instead of throwing an exception since this is a
+     *          an optional header in B2.  Older files will not have it.
+     */
+    default String getContentMd5OrNull() {
+        return getValueOrNull(CONTENT_MD5);
     }
 
     /**

--- a/core/src/main/java/com/backblaze/b2/client/structures/B2FileVersion.java
+++ b/core/src/main/java/com/backblaze/b2/client/structures/B2FileVersion.java
@@ -35,6 +35,8 @@ public class B2FileVersion {
     private final String contentType;
     @B2Json.optional // for example, "folder"s don't have contentSha1s nor do largeFiles.
     private final String contentSha1;
+    @B2Json.optional // for example, "folder"s don't have contentMd5s nor do largeFiles.
+    private final String contentMd5;
     @B2Json.optional
     private final Map<String,String> fileInfo;
     @B2Json.optional  // for example, large files don't have action in response from b2_start_large_file.
@@ -43,12 +45,13 @@ public class B2FileVersion {
     private final long uploadTimestamp;
 
     @B2Json.constructor(params = "fileId,fileName,contentLength,contentType," +
-            "contentSha1,fileInfo,action,uploadTimestamp")
+            "contentSha1,contentMd5,fileInfo,action,uploadTimestamp")
     public B2FileVersion(String fileId,
                          String fileName,
                          long contentLength,
                          String contentType,
                          String contentSha1,
+                         String contentMd5,
                          Map<String, String> fileInfo,
                          String action,
                          long uploadTimestamp) {
@@ -57,6 +60,7 @@ public class B2FileVersion {
         this.contentLength = contentLength;
         this.contentType = contentType;
         this.contentSha1 = contentSha1;
+        this.contentMd5 = contentMd5;
         this.fileInfo = fileInfo;
         this.action = action;
         this.uploadTimestamp = uploadTimestamp;
@@ -80,6 +84,10 @@ public class B2FileVersion {
 
     public String getContentSha1() {
         return contentSha1;
+    }
+
+    public String getContentMd5() {
+        return contentMd5;
     }
 
     public String getLargeFileSha1OrNull() {
@@ -121,6 +129,7 @@ public class B2FileVersion {
                 ", contentLength=" + contentLength +
                 ", contentType='" + contentType + '\'' +
                 ", contentSha1='" + contentSha1 + '\'' +
+                ", contentMd5='" + contentMd5 + '\'' +
                 ", action='" + action + '\'' +
                 ", uploadTimestamp=" + uploadTimestamp +
                 ", fileInfo=[" + fileInfo.size() + "]" +
@@ -139,12 +148,13 @@ public class B2FileVersion {
                 Objects.equals(getFileName(), that.getFileName()) &&
                 Objects.equals(getContentType(), that.getContentType()) &&
                 Objects.equals(getContentSha1(), that.getContentSha1()) &&
+                Objects.equals(getContentMd5(), that.getContentMd5()) &&
                 Objects.equals(getFileInfo(), that.getFileInfo()) &&
                 Objects.equals(getAction(), that.getAction());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getFileId(), getFileName(), getContentLength(), getContentType(), getContentSha1(), getFileInfo(), getAction(), getUploadTimestamp());
+        return Objects.hash(getFileId(), getFileName(), getContentLength(), getContentType(), getContentSha1(), getContentMd5(), getFileInfo(), getAction(), getUploadTimestamp());
     }
 }

--- a/core/src/main/java/com/backblaze/b2/client/structures/B2Part.java
+++ b/core/src/main/java/com/backblaze/b2/client/structures/B2Part.java
@@ -22,7 +22,7 @@ public class B2Part {
     @B2Json.optional  // not present in response from b2_upload_part.
     private final long uploadTimestamp;
 
-    @B2Json.constructor(params = "fileId,partNumber,contentLength,contentSha1,uploadTimestamp")
+    @B2Json.constructor(params = "fileId,partNumber,contentLength,contentSha1,contentMd5,uploadTimestamp")
     public B2Part(String fileId,
                   int partNumber,
                   long contentLength,

--- a/core/src/main/java/com/backblaze/b2/client/structures/B2Part.java
+++ b/core/src/main/java/com/backblaze/b2/client/structures/B2Part.java
@@ -17,6 +17,8 @@ public class B2Part {
     private final long contentLength;
     @B2Json.required
     private final String contentSha1;
+    @B2Json.optional
+    private final String contentMd5;
     @B2Json.optional  // not present in response from b2_upload_part.
     private final long uploadTimestamp;
 
@@ -25,11 +27,13 @@ public class B2Part {
                   int partNumber,
                   long contentLength,
                   String contentSha1,
+                  String contentMd5,
                   long uploadTimestamp) {
         this.fileId = fileId;
         this.partNumber = partNumber;
         this.contentLength = contentLength;
         this.contentSha1 = contentSha1;
+        this.contentMd5 = contentMd5;
         this.uploadTimestamp = uploadTimestamp;
     }
 
@@ -50,6 +54,10 @@ public class B2Part {
         return contentSha1;
     }
 
+    public String getContentMd5() {
+        return contentMd5;
+    }
+
     public long getUploadTimestamp() {
         return uploadTimestamp;
     }
@@ -63,12 +71,13 @@ public class B2Part {
                 getContentLength() == b2Part.getContentLength() &&
                 getUploadTimestamp() == b2Part.getUploadTimestamp() &&
                 Objects.equals(getFileId(), b2Part.getFileId()) &&
-                Objects.equals(getContentSha1(), b2Part.getContentSha1());
+                Objects.equals(getContentSha1(), b2Part.getContentSha1()) &&
+                Objects.equals(getContentMd5(), b2Part.getContentMd5());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getFileId(), getPartNumber(), getContentLength(), getContentSha1(), getUploadTimestamp());
+        return Objects.hash(getFileId(), getPartNumber(), getContentLength(), getContentSha1(), getContentMd5(), getUploadTimestamp());
     }
 
     @Override

--- a/core/src/main/java/com/backblaze/b2/util/B2Md5.java
+++ b/core/src/main/java/com/backblaze/b2/util/B2Md5.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2020, Backblaze Inc. All Rights Reserved.
+ * License https://www.backblaze.com/using_b2_code.html
+ */
+
+package com.backblaze.b2.util;
+
+public interface B2Md5 {
+    int MD5_SIZE = 20;
+    int HEX_MD5_SIZE = 2 * MD5_SIZE;
+}

--- a/core/src/test/java/com/backblaze/b2/client/B2AlreadyStoredPartStorerTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2AlreadyStoredPartStorerTest.java
@@ -10,6 +10,7 @@ import com.backblaze.b2.util.B2BaseTest;
 import org.junit.Test;
 
 import static com.backblaze.b2.client.B2TestHelpers.fileId;
+import static com.backblaze.b2.client.B2TestHelpers.makeMd5;
 import static com.backblaze.b2.client.B2TestHelpers.makeSha1;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -20,7 +21,7 @@ public class B2AlreadyStoredPartStorerTest extends B2BaseTest {
 
     @Test
     public void testStorePart() {
-        final B2Part part = new B2Part(fileId(1), 2, 10000000, makeSha1(1), 1111);
+        final B2Part part = new B2Part(fileId(1), 2, 10000000, makeSha1(1), makeMd5(2), 1111);
         final B2AlreadyStoredPartStorer partStorer = new B2AlreadyStoredPartStorer(part);
         assertEquals(part, partStorer.storePart(mock(B2LargeFileStorer.class), uploadListener));
     }

--- a/core/src/test/java/com/backblaze/b2/client/B2CopyingPartStorerTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2CopyingPartStorerTest.java
@@ -12,6 +12,7 @@ import com.backblaze.b2.util.B2ByteRange;
 import org.junit.Test;
 
 import static com.backblaze.b2.client.B2TestHelpers.fileId;
+import static com.backblaze.b2.client.B2TestHelpers.makeMd5;
 import static com.backblaze.b2.client.B2TestHelpers.makeSha1;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.anyInt;
@@ -27,8 +28,9 @@ public class B2CopyingPartStorerTest extends B2BaseTest {
     private static final String DST_FILE_ID = fileId(2);
     private static final int PART_NUMBER = 2;
     private static final String SHA1 = makeSha1(2);
+    private static final String MD5 = makeMd5(2);
 
-    private final B2Part part = new B2Part(DST_FILE_ID, PART_NUMBER, 5000000, SHA1, 2222);
+    private final B2Part part = new B2Part(DST_FILE_ID, PART_NUMBER, 5000000, SHA1, MD5, 2222);
     private final B2LargeFileStorer largeFileStorer = mock(B2LargeFileStorer.class);
 
     private final B2UploadListener uploadListener = mock(B2UploadListener.class);

--- a/core/src/test/java/com/backblaze/b2/client/B2LargeFileStorerTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2LargeFileStorerTest.java
@@ -34,6 +34,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static com.backblaze.b2.client.B2TestHelpers.fileId;
+import static com.backblaze.b2.client.B2TestHelpers.makeMd5;
 import static com.backblaze.b2.client.B2TestHelpers.makeSha1;
 import static com.backblaze.b2.client.B2TestHelpers.makeVersion;
 import static junit.framework.TestCase.assertEquals;
@@ -62,9 +63,9 @@ public class B2LargeFileStorerTest extends B2BaseTest {
     private final B2FileVersion largeFileVersion = makeVersion(4, 4);
 
     // Set up the parts of the large file.
-    private final B2Part part1 = new B2Part(fileId(1), 1, PART_SIZE_FOR_FIRST_TWO, makeSha1(1), 1111);
-    private final B2Part part2 = new B2Part(fileId(2), 2, PART_SIZE_FOR_FIRST_TWO, makeSha1(2), 2222);
-    private final B2Part part3 = new B2Part(fileId(3), 3, LAST_PART_SIZE, makeSha1(3), 3333);
+    private final B2Part part1 = new B2Part(fileId(1), 1, PART_SIZE_FOR_FIRST_TWO, makeSha1(1), makeMd5(1), 1111);
+    private final B2Part part2 = new B2Part(fileId(2), 2, PART_SIZE_FOR_FIRST_TWO, makeSha1(2), makeMd5(2), 2222);
+    private final B2Part part3 = new B2Part(fileId(3), 3, LAST_PART_SIZE, makeSha1(3), makeMd5(3), 3333);
 
 
     private final B2PartSizes partSizes;

--- a/core/src/test/java/com/backblaze/b2/client/B2LargeFileUploaderTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2LargeFileUploaderTest.java
@@ -55,6 +55,7 @@ import static com.backblaze.b2.client.B2LargeFileUploaderTest.When.IN_SUBMIT;
 import static com.backblaze.b2.client.B2TestHelpers.bucketId;
 import static com.backblaze.b2.client.B2TestHelpers.fileId;
 import static com.backblaze.b2.client.B2TestHelpers.fileName;
+import static com.backblaze.b2.client.B2TestHelpers.makeMd5;
 import static com.backblaze.b2.client.B2TestHelpers.makePart;
 import static com.backblaze.b2.client.B2TestHelpers.makeSha1;
 import static com.backblaze.b2.client.B2TestHelpers.makeVersion;
@@ -220,6 +221,7 @@ public class B2LargeFileUploaderTest extends B2BaseTest {
                 contentSource.getContentLength(),
                 B2ContentTypes.B2_AUTO,
                 null,
+                null,
                 B2Collections.mapOf(),
                 "upload",
                 123L);
@@ -324,6 +326,7 @@ public class B2LargeFileUploaderTest extends B2BaseTest {
                 contentSource.getContentLength(),
                 B2ContentTypes.APPLICATION_OCTET,
                 null, // sha1
+                null, // md5
                 B2Collections.mapOf(),
                 "action",
                 1234
@@ -345,6 +348,7 @@ public class B2LargeFileUploaderTest extends B2BaseTest {
                 contentSource.getContentLength(),
                 B2ContentTypes.APPLICATION_OCTET,
                 null, // sha1 of the file (always null for large files.  they use LARGE_FILE_SHA1!)
+                null, // md5 of the file
                 B2Collections.mapOf(B2Headers.LARGE_FILE_SHA1_INFO_NAME, makeSha1(1)),
                 "action",
                 1234
@@ -365,6 +369,7 @@ public class B2LargeFileUploaderTest extends B2BaseTest {
                 fileName(2),
                 contentSource.getContentLength(),
                 B2ContentTypes.TEXT_PLAIN,  // this is the mismatch!
+                null,
                 null,
                 B2Collections.mapOf(),
                 "action",
@@ -387,6 +392,7 @@ public class B2LargeFileUploaderTest extends B2BaseTest {
                 contentSource.getContentLength(),
                 B2ContentTypes.TEXT_PLAIN,  // this is NOT a mismatch, because request is B2_AUTO.
                 null,
+                null,
                 B2Collections.mapOf(),
                 "action",
                 1234
@@ -407,6 +413,7 @@ public class B2LargeFileUploaderTest extends B2BaseTest {
                 fileName(2),
                 contentSource.getContentLength(),
                 B2ContentTypes.APPLICATION_OCTET,
+                null,
                 null,
                 B2Collections.mapOf(),
                 "action",
@@ -441,7 +448,7 @@ public class B2LargeFileUploaderTest extends B2BaseTest {
     public void testOneAlreadyUploadedPartThatMatches_part1() throws IOException, B2Exception {
         final String largeFileId = fileId(1);
         final List<B2Part> alreadyUploadedParts = B2Collections.listOf(
-                new B2Part(largeFileId, 1, 1041, makeSha1(1), 1111)
+                new B2Part(largeFileId, 1, 1041, makeSha1(1), makeMd5(1), 1111)
         );
 
         recordingListener.setExpected(
@@ -463,7 +470,7 @@ public class B2LargeFileUploaderTest extends B2BaseTest {
     public void testOneAlreadyUploadedPartThatMatches_part3() throws IOException, B2Exception {
         final String largeFileId = fileId(1);
         final List<B2Part> alreadyUploadedParts = B2Collections.listOf(
-                new B2Part(largeFileId, 3, 1042, makeSha1(3), 3333)
+                new B2Part(largeFileId, 3, 1042, makeSha1(3), makeMd5(3), 3333)
         );
 
         recordingListener.setExpected(
@@ -484,9 +491,9 @@ public class B2LargeFileUploaderTest extends B2BaseTest {
     public void testThreeAlreadyUploadedParts_allMatch() throws IOException, B2Exception {
         final String largeFileId = fileId(1);
         final List<B2Part> alreadyUploadedParts = B2Collections.listOf( // out-of-order on purpose.  should still be found.
-                new B2Part(largeFileId, 3, 1042, makeSha1(3), 3333),
-                new B2Part(largeFileId, 2, 1041, makeSha1(2), 2222),
-                new B2Part(largeFileId, 1, 1041, makeSha1(1), 1111)
+                new B2Part(largeFileId, 3, 1042, makeSha1(3), makeMd5(3), 3333),
+                new B2Part(largeFileId, 2, 1041, makeSha1(2), makeMd5(2), 2222),
+                new B2Part(largeFileId, 1, 1041, makeSha1(1), makeMd5(1), 1111)
         );
 
         recordingListener.setExpected(
@@ -505,10 +512,10 @@ public class B2LargeFileUploaderTest extends B2BaseTest {
     public void testFourAlreadyUploadedPart_noneMatch() throws IOException, B2Exception {
         final String largeFileId = fileId(1);
         final List<B2Part> alreadyUploadedParts = B2Collections.listOf(
-                new B2Part(largeFileId, 6, 1041, makeSha1(1), 1111),  // unneeded part number
-                new B2Part(largeFileId, 2, 6666, makeSha1(2), 2222),  // bad size
-                new B2Part(largeFileId, 3, 1041, makeSha1(3), 3333),  // bad size
-                new B2Part(largeFileId, 4, 1041, makeSha1(4), 1111)   // unneeded part number
+                new B2Part(largeFileId, 6, 1041, makeSha1(1), makeMd5(1), 1111),  // unneeded part number
+                new B2Part(largeFileId, 2, 6666, makeSha1(2), makeMd5(2), 2222),  // bad size
+                new B2Part(largeFileId, 3, 1041, makeSha1(3), makeMd5(3), 3333),  // bad size
+                new B2Part(largeFileId, 4, 1041, makeSha1(4), makeMd5(4), 1111)   // unneeded part number
         );
 
         recordingListener.setExpected(
@@ -539,6 +546,7 @@ public class B2LargeFileUploaderTest extends B2BaseTest {
                 fileName(1),
                 contentLen,
                 B2ContentTypes.APPLICATION_OCTET,
+                null,
                 null,
                 B2Collections.mapOf(),
                 "upload",

--- a/core/src/test/java/com/backblaze/b2/client/B2ListPartsIterableImplTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2ListPartsIterableImplTest.java
@@ -19,6 +19,7 @@ import org.junit.rules.ExpectedException;
 import java.util.Iterator;
 import java.util.List;
 
+import static com.backblaze.b2.client.B2TestHelpers.SAMPLE_MD5;
 import static com.backblaze.b2.client.B2TestHelpers.SAMPLE_SHA1;
 import static com.backblaze.b2.client.B2TestHelpers.fileId;
 import static org.junit.Assert.assertTrue;
@@ -202,6 +203,7 @@ public class B2ListPartsIterableImplTest extends B2BaseTest {
                 i,
                 i * 1000 * 1000,
                 SAMPLE_SHA1,
+                SAMPLE_MD5,
                 i);
     }
 }

--- a/core/src/test/java/com/backblaze/b2/client/B2StorageClientImplTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2StorageClientImplTest.java
@@ -77,6 +77,7 @@ import static com.backblaze.b2.client.B2TestHelpers.bucketId;
 import static com.backblaze.b2.client.B2TestHelpers.bucketName;
 import static com.backblaze.b2.client.B2TestHelpers.fileId;
 import static com.backblaze.b2.client.B2TestHelpers.fileName;
+import static com.backblaze.b2.client.B2TestHelpers.makeMd5;
 import static com.backblaze.b2.client.B2TestHelpers.makePart;
 import static com.backblaze.b2.client.B2TestHelpers.makeSha1;
 import static com.backblaze.b2.client.B2TestHelpers.makeVersion;
@@ -920,6 +921,7 @@ public class B2StorageClientImplTest extends B2BaseTest {
                 contentLen,
                 B2ContentTypes.TEXT_PLAIN,
                 null,
+                null,
                 B2Collections.mapOf(),
                 "upload",
                 B2Clock.get().wallClockMillis());
@@ -928,8 +930,8 @@ public class B2StorageClientImplTest extends B2BaseTest {
 
         // arrange to find that two parts -- the first and third -- have already been uploaded.
         final List<B2Part> alreadyUploadedParts = listOf(
-                new B2Part(largeFileId, 1, 1041, makeSha1(1), 1111),
-                new B2Part(largeFileId, 3, 1042, makeSha1(3), 3333)
+                new B2Part(largeFileId, 1, 1041, makeSha1(1), makeMd5(1), 1111),
+                new B2Part(largeFileId, 3, 1042, makeSha1(3), makeMd5(3), 3333)
         );
         final B2ListPartsResponse listPartsResponse = new B2ListPartsResponse(alreadyUploadedParts, null);
         when(webifier.listParts(anyObject(), anyObject())).thenReturn(listPartsResponse);

--- a/core/src/test/java/com/backblaze/b2/client/B2TestHelpers.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2TestHelpers.java
@@ -20,6 +20,7 @@ import com.backblaze.b2.client.structures.B2UploadPartUrlResponse;
 import com.backblaze.b2.client.structures.B2UploadUrlResponse;
 import com.backblaze.b2.util.B2Clock;
 import com.backblaze.b2.util.B2Collections;
+import com.backblaze.b2.util.B2Md5;
 import com.backblaze.b2.util.B2Sha1;
 
 import java.util.Collections;
@@ -36,6 +37,7 @@ import static com.backblaze.b2.util.B2StringUtil.percentEncode;
 
 public class B2TestHelpers {
     public static final String SAMPLE_SHA1 = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
+    public static final String SAMPLE_MD5 = "d41d8cd98f00b204e9800998ecf8427e";
 
     /**
      * @return a bucketId based on the provided number.  it's a bogus id, but readable.
@@ -106,6 +108,7 @@ public class B2TestHelpers {
                 iId * 1000,
                 B2ContentTypes.TEXT_PLAIN,
                 SAMPLE_SHA1,
+                SAMPLE_MD5,
                 B2Collections.mapOf(),
                 "upload",
                 B2Clock.get().wallClockMillis());
@@ -118,6 +121,7 @@ public class B2TestHelpers {
                 i,
                 i * 1000,
                 makeSha1(i),
+                makeMd5(i),
                 i);
     }
 
@@ -140,6 +144,16 @@ public class B2TestHelpers {
             copies.append(toCopy);
         }
         return copies.toString().substring(0, B2Sha1.HEX_SHA1_SIZE);
+    }
+
+    // returns a string that's as long as an md5 hex string should be, based on 'i'.
+    public static String makeMd5(int i) {
+        String toCopy = Integer.toString(i);
+        StringBuilder copies = new StringBuilder();
+        while (copies.length() < B2Md5.HEX_MD5_SIZE) {
+            copies.append(toCopy);
+        }
+        return copies.toString().substring(0, B2Md5.HEX_MD5_SIZE);
     }
 
     public static B2Bucket makeBucket(int i) {

--- a/core/src/test/java/com/backblaze/b2/client/B2UploadingPartStorerTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2UploadingPartStorerTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import java.io.IOException;
 
 import static com.backblaze.b2.client.B2TestHelpers.fileId;
+import static com.backblaze.b2.client.B2TestHelpers.makeMd5;
 import static com.backblaze.b2.client.B2TestHelpers.makeSha1;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.anyInt;
@@ -27,8 +28,9 @@ public class B2UploadingPartStorerTest extends B2BaseTest {
     private static final String FILE_ID = fileId(2);
     private static final int PART_NUMBER = 2;
     private static final String SHA1 = makeSha1(2);
+    private static final String MD5 = makeMd5(2);
 
-    private final B2Part part = new B2Part(FILE_ID, PART_NUMBER, 5000000, SHA1, 2222);
+    private final B2Part part = new B2Part(FILE_ID, PART_NUMBER, 5000000, SHA1, MD5, 2222);
 
     private final B2UploadListener uploadListener = mock(B2UploadListener.class);
 

--- a/core/src/test/java/com/backblaze/b2/client/structures/B2FileVersionTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/structures/B2FileVersionTest.java
@@ -6,6 +6,7 @@ package com.backblaze.b2.client.structures;
 
 import com.backblaze.b2.client.B2TestHelpers;
 import com.backblaze.b2.client.contentSources.B2ContentTypes;
+import com.backblaze.b2.json.B2Json;
 import com.backblaze.b2.util.B2BaseTest;
 import com.backblaze.b2.util.B2Collections;
 import org.junit.Test;
@@ -42,6 +43,18 @@ public class B2FileVersionTest extends B2BaseTest {
         checkAction(B2FileVersion.START_ACTION, false, false, true, false);
         checkAction(B2FileVersion.FOLDER_ACTION, false, false, false, true);
         checkAction(null, false, false, false, false);
+    }
+
+    @Test
+    public void testJson() {
+        final B2FileVersion fileVersion = make(1);
+        assertEquals(
+                fileVersion,
+                B2Json.fromJsonOrThrowRuntime(
+                        B2Json.toJsonOrThrowRuntime(fileVersion),
+                        B2FileVersion.class
+                )
+        );
     }
 
     private void checkAction(String action, boolean expectUpload, boolean expectHide, boolean expectStart, boolean expectFolder) {

--- a/core/src/test/java/com/backblaze/b2/client/structures/B2FileVersionTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/structures/B2FileVersionTest.java
@@ -28,7 +28,7 @@ public class B2FileVersionTest extends B2BaseTest {
         assertEquals(one, one);
         assertEquals(one, make(1));
 
-        assertEquals("B2FileVersion{fileId='" + fileId(1) + "', contentLength=1000, contentType='text/plain', contentSha1='" + B2TestHelpers.SAMPLE_SHA1 + "', action='upload', uploadTimestamp=1, fileInfo=[1], fileName='" + fileName(1) + "'}", one.toString());
+        assertEquals("B2FileVersion{fileId='" + fileId(1) + "', contentLength=1000, contentType='text/plain', contentSha1='" + B2TestHelpers.SAMPLE_SHA1 + "', contentMd5='" + B2TestHelpers.SAMPLE_MD5 + "', action='upload', uploadTimestamp=1, fileInfo=[1], fileName='" + fileName(1) + "'}", one.toString());
 
         // just for code coverage.
         //noinspection ResultOfMethodCallIgnored
@@ -52,6 +52,7 @@ public class B2FileVersionTest extends B2BaseTest {
                         0L,
                         "contentType",
                         "contentSha1",
+                        "contentMd5",
                         new HashMap<>(),
                         action,
                         0L
@@ -69,6 +70,7 @@ public class B2FileVersionTest extends B2BaseTest {
                 i * 1000,
                 B2ContentTypes.TEXT_PLAIN,
                 B2TestHelpers.SAMPLE_SHA1,
+                B2TestHelpers.SAMPLE_MD5,
                 B2Collections.mapOf("key" + i, "value" + i),
                 "upload",
                 i);

--- a/core/src/test/java/com/backblaze/b2/client/structures/B2PartTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/structures/B2PartTest.java
@@ -4,6 +4,7 @@
  */
 package com.backblaze.b2.client.structures;
 
+import com.backblaze.b2.json.B2Json;
 import com.backblaze.b2.util.B2BaseTest;
 import org.junit.Test;
 
@@ -13,6 +14,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 public class B2PartTest extends B2BaseTest {
+
     @Test
     public void test() {
         B2Part one = makePart(1);
@@ -27,5 +29,17 @@ public class B2PartTest extends B2BaseTest {
         // for coverage
         //noinspection ResultOfMethodCallIgnored
         one.hashCode();
+    }
+
+    @Test
+    public void testJson() {
+        final B2Part part = makePart(1);
+        assertEquals(
+                part,
+                B2Json.fromJsonOrThrowRuntime(
+                        B2Json.toJsonOrThrowRuntime(part),
+                        B2Part.class
+                )
+        );
     }
 }


### PR DESCRIPTION
B2 will soon be returning these fields, and it will be good to let
client code see them.  The first code that needs them will be internal
Backblaze tests that exercise the B2 APIs.

B2Headers now has a getContentMd5() method, which reads the "Content-MD5"
header that will be returned when downloading a file.  This header is
also used when getting file info by name; the info is returned in the
headers from a HEAD request on the file.

Testing: All Tests