### PR TITLE
Disable URI normalization in Apache HttpClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [Unreleased]
 ### Changed `[Incompatible]`
 * B2Bucket and B2ApplicationKey both have an `options` parameter in the constructor.  These are optional.
-
+* `B2StorageClient.DownloadByName` supports downloading files with looser naming requirements, e.g. names containing double slashes (`//`).
+* Updated to version `4.5.9` of `org.apache.httpcomponents:httpclient`. 
 ## [3.1.0] - 2019-05-16
 ### Added
 * Added `@B2Json.sensitive` annotation to redact fields when B2Json is

--- a/httpclient/build.gradle
+++ b/httpclient/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     compile project(':core')
     
     // apache http commons (https://hc.apache.org/httpcomponents-client-ga/httpclient/dependency-info.html)
-    compile 'org.apache.httpcomponents:httpclient:4.5.3'
+    compile 'org.apache.httpcomponents:httpclient:4.5.9'
 
     // apache commons logging  (https://mvnrepository.com/artifact/commons-logging/commons-logging/1.2)
     implementation group: 'commons-logging', name: 'commons-logging', version: '1.2'

--- a/httpclient/src/main/java/com/backblaze/b2/client/webApiHttpClient/HttpClientFactoryImpl.java
+++ b/httpclient/src/main/java/com/backblaze/b2/client/webApiHttpClient/HttpClientFactoryImpl.java
@@ -166,6 +166,9 @@ public class HttpClientFactoryImpl implements HttpClientFactory {
                     .setConnectionRequestTimeout(connectionRequestTimeoutSeconds * 1000) // time waiting for cxn from pool
                     .setConnectTimeout(connectTimeoutSeconds * 1000) // time waiting for remote server to connect
                     .setSocketTimeout(socketTimeoutSeconds * 1000) // time waiting for answer after connecting
+                    // don't try to normalize URIs, like convert '//' to '/'; this would change filenames for
+                    // DownloadByName requests
+                    .setNormalizeUri(false)
                     .build();
 
         }


### PR DESCRIPTION
By default, HttpClient will normalize URIs, which includes replacing double slashes (`//`) with a single slash. This will alter the request URI and implicitly change the name of files requested through the DownloadByName API where the filename is part of the URI. We need to disable this normalization to allow filename requests to go through as-is.

Updating the HttpClient version to 4.5.9 which is the first version that the setNormalizeUri option became available.