### PR TITLE
B2Json: Allow generic types for top-level objects from select entry points

### DIFF
--- a/core/src/main/java/com/backblaze/b2/json/B2Json.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2Json.java
@@ -169,15 +169,8 @@ public class B2Json {
     }
 
     public String toJson(Object obj, B2JsonOptions options) throws B2JsonException {
-        if (obj == null) {
-            throw new B2JsonException("top level object must not be null");
-        }
-        Class<?> clazz = obj.getClass();
-        final B2JsonTypeHandler handler = handlerMap.getHandler(clazz);
         try (final ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-            B2JsonWriter jsonWriter = new B2JsonWriter(out, options);
-            //noinspection unchecked
-            handler.serialize(obj, options, jsonWriter);
+            toJson(obj, options, out);
             return out.toString(B2StringUtil.UTF8);
         } catch (IOException e) {
             throw new RuntimeException("IO exception writing to string");

--- a/core/src/main/java/com/backblaze/b2/json/B2Json.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2Json.java
@@ -140,10 +140,17 @@ public class B2Json {
         }
     }
 
+    /**
+     * Turn an object into JSON, writing the results to given output stream.
+     */
     public void toJson(Object obj, OutputStream out) throws IOException, B2JsonException {
         toJson(obj, B2JsonOptions.DEFAULT, out);
     }
 
+    /**
+     * Turn an object into JSON, writing the results to given output stream and
+     * using the supplied options.
+     */
     public void toJson(Object obj, B2JsonOptions options, OutputStream out) throws IOException, B2JsonException {
         toJson(obj, options, out, null);
     }
@@ -157,6 +164,10 @@ public class B2Json {
      * you will need to pass in its type information via objTypeOrNull. This will instruct
      * B2Json to derive the B2JsonTypeHandler from the type information instead of the
      * object's class.
+     *
+     * Getting the Type of obj can be done in at least two ways:
+     * 1. If it is a member of an enclosing class, EnclosingClass.getDeclaredField(...).getGenericType()
+     * 2. By constructing a class that implements Type.
      *
      * Note that the output stream is NOT closed as a side-effect of calling this.
      * It was a bug that it was being closed in version 1.1.1 and earlier.
@@ -346,6 +357,17 @@ public class B2Json {
         return fromJson(in, clazz, optionsFromFlags(optionFlags));
     }
 
+    /**
+     * Parse the bytes from an InputStream as JSON using the supplied options, returning the parsed object.
+     *
+     * The Type parameter will usually be a class, which is straightforward to supply. However,
+     * if you are trying to deserialize a parameterized type (like if obj is a
+     * {@literal List<String>}, then you will need to supply a proper Type instance.
+     *
+     * Getting the Type can be done in at least two ways:
+     * 1. If it is a member of an enclosing class, EnclosingClass.getDeclaredField(...).getGenericType()
+     * 2. By constructing a class that implements Type.
+     */
     public <T> T fromJson(InputStream in, Type type, B2JsonOptions options) throws IOException, B2JsonException {
         B2JsonReader reader = new B2JsonReader(new InputStreamReader(in, "UTF-8"));
         final B2JsonTypeHandler handler = handlerMap.getHandler(type);

--- a/core/src/main/java/com/backblaze/b2/json/B2JsonHandlerMap.java
+++ b/core/src/main/java/com/backblaze/b2/json/B2JsonHandlerMap.java
@@ -118,7 +118,7 @@ public class B2JsonHandlerMap {
      * <p>
      * So, this method does NOT need to be re-entrant, and in fact we assume that it's not.
      */
-    public synchronized <T> B2JsonTypeHandler<T> getHandler(Class<T> clazz) throws B2JsonException {
+    public synchronized <T> B2JsonTypeHandler<T> getHandler(Type type) throws B2JsonException {
         // This method is NOT re-entrant.  The code that creates and initializes new handlers
         // should not call this method.
         //
@@ -132,7 +132,7 @@ public class B2JsonHandlerMap {
 
         // Fast path (without try/catch/finally) for the case where the handler is already in the map.
         {
-            final B2JsonTypeHandler<T> existingHandlerOrNull = lookupHandler(clazz);
+            final B2JsonTypeHandler<T> existingHandlerOrNull = lookupHandler(type);
             if (existingHandlerOrNull != null) {
                 return existingHandlerOrNull;
             }
@@ -143,7 +143,7 @@ public class B2JsonHandlerMap {
         final List<B2JsonTypeHandler> handlersToCheckDefaults;
         try {
             // Create any handlers that need to be created.
-            handler = getUninitializedHandler(clazz);
+            handler = getUninitializedHandler(type);
 
             // Initialize handlers that were created.  Note that initializing a new handler
             // may result in new handlers being added to handlersAddedToMap, so this loop

--- a/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
+++ b/core/src/test/java/com/backblaze/b2/json/B2JsonTest.java
@@ -7,6 +7,7 @@ package com.backblaze.b2.json;
 
 import com.backblaze.b2.util.B2BaseTest;
 import com.backblaze.b2.util.B2Preconditions;
+import com.backblaze.b2.util.B2StringUtil;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -2458,6 +2459,28 @@ public class B2JsonTest extends B2BaseTest {
         final SerializationTestClass derived = B2Json.get().fromJson(actual, SerializationTestClass.class);
 
         assertEquals(original, derived);
+    }
+
+    @Test
+    public void testTopLevelObjectIsParameterizedType() throws NoSuchFieldException, IOException, B2JsonException {
+        final Item<Integer> item = new Item<>(123);
+
+        // Get a reference to a type object that describes an Item<Integer>...
+        final Type type = ClassThatUsesGenerics.class.getDeclaredField("integerItem").getGenericType();
+
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        B2Json.get().toJson(item, B2JsonOptions.DEFAULT, out, type);
+        final String json = out.toString(B2StringUtil.UTF8);
+
+        assertEquals("{\n" +
+                "  \"value\": 123\n" +
+                "}",
+                json);
+
+        // Now try without the type information
+        thrown.expect(B2JsonException.class);
+        thrown.expectMessage("actualTypeArguments must be same length as class' type parameters");
+        B2Json.get().toJson(item, B2JsonOptions.DEFAULT, out);
     }
 
     @Test


### PR DESCRIPTION
This allows the user to supply type information to aid in `B2JsonTypeHandler` resolution for the top-level object. If the type information is not supplied, `B2Json` falls back to the existing behavior of resolving by class.

The first commit is a small refactor.
Second is the feature.
Third is a test.