### PR TITLE
validate chars in file info header name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * B2Bucket and B2ApplicationKey both have an `options` parameter in the constructor.  These are optional.
 * `B2StorageClient.DownloadByName` supports downloading files with looser naming requirements, e.g. names containing double slashes (`//`).
 * Updated to version `4.5.9` of `org.apache.httpcomponents:httpclient`. 
+* When uploading files, the characters in the fileInfo header names are now validated against the list of 
+  acceptable characters in RFC 7230 `https://tools.ietf.org/html/rfc7230#section-3.2`
 ## [3.1.0] - 2019-05-16
 ### Added
 * Added `@B2Json.sensitive` annotation to redact fields when B2Json is

--- a/core/src/main/java/com/backblaze/b2/client/B2StorageClientWebifierImpl.java
+++ b/core/src/main/java/com/backblaze/b2/client/B2StorageClientWebifierImpl.java
@@ -96,12 +96,6 @@ public class B2StorageClientWebifierImpl implements B2StorageClientWebifier {
     private final String masterUrl;
     private final B2TestMode testModeOrNull;
 
-    /**
-     * Special chars allowed in header as defined by: https://tools.ietf.org/html/rfc7230#section-3.2.6
-     */
-    private static final char[] HEADER_SPECIAL_CHARS_RFC7230 = new char[] { '!', '#', '$', '%', '&', '\'', '*',
-            '+', '-', '.', '^', '_', '`', '|', '~' };
-
     public B2StorageClientWebifierImpl(B2WebApiClient webApiClient,
                                        String userAgent,
                                        String masterUrl,
@@ -695,10 +689,9 @@ public class B2StorageClientWebifierImpl implements B2StorageClientWebifier {
      * @param name The String to validate
      * @throws B2BadRequestException if any of the characters are not valid
      */
-    private void validateFileInfoName(String name) throws B2BadRequestException {
-
-        for (char c : name.toCharArray()) {
-            if (!isLegalInfoNameCharacter(c)) {
+    /*testing*/ void validateFileInfoName(String name) throws B2BadRequestException {
+        for (int i = 0; i < name.length(); i++) {
+            if (!isLegalInfoNameCharacter(name.charAt(i))) {
                 throw new B2BadRequestException(B2BadRequestException.DEFAULT_CODE,
                         null,
                         "Illegal file info name: " + name);
@@ -707,19 +700,24 @@ public class B2StorageClientWebifierImpl implements B2StorageClientWebifier {
     }
 
     private boolean isLegalInfoNameCharacter(char c) {
-        return ('a' <= c && c <= 'z') ||
+        return
+                ('a' <= c && c <= 'z') ||
                 ('A' <= c && c <= 'Z') ||
                 ('0' <= c && c <= '9') ||
-                isRFC7230SpecialChar(c);
-    }
-
-    private boolean isRFC7230SpecialChar(char c) {
-        for (char specialChar : HEADER_SPECIAL_CHARS_RFC7230) {
-            if (c == specialChar) {
-                return true;
-            }
-        }
-
-        return false;
+                c == '-'  ||
+                c == '_'  ||
+                c == '.'  ||
+                c == '!'  ||
+                c == '#'  ||
+                c == '$'  ||
+                c == '%'  ||
+                c == '&'  ||
+                c == '\'' ||
+                c == '*'  ||
+                c == '+'  ||
+                c == '^'  ||
+                c == '`'  ||
+                c == '|'  ||
+                c == '~';
     }
 }

--- a/core/src/main/java/com/backblaze/b2/client/B2StorageClientWebifierImpl.java
+++ b/core/src/main/java/com/backblaze/b2/client/B2StorageClientWebifierImpl.java
@@ -697,8 +697,8 @@ public class B2StorageClientWebifierImpl implements B2StorageClientWebifier {
      */
     private void validateFileInfoName(String name) throws B2BadRequestException {
 
-        for (int i = 0; i < name.length(); i++) {
-            if (!isLegalInfoNameCharacter(name.charAt(i))) {
+        for (char c : name.toCharArray()) {
+            if (!isLegalInfoNameCharacter(c)) {
                 throw new B2BadRequestException(B2BadRequestException.DEFAULT_CODE,
                         null,
                         "Illegal file info name: " + name);

--- a/core/src/main/java/com/backblaze/b2/client/B2StorageClientWebifierImpl.java
+++ b/core/src/main/java/com/backblaze/b2/client/B2StorageClientWebifierImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, Backblaze Inc. All Rights Reserved.
+ * Copyright 2020, Backblaze Inc. All Rights Reserved.
  * License https://www.backblaze.com/using_b2_code.html
  */
 package com.backblaze.b2.client;
@@ -8,6 +8,7 @@ import com.backblaze.b2.client.contentHandlers.B2ContentSink;
 import com.backblaze.b2.client.contentSources.B2ContentSource;
 import com.backblaze.b2.client.contentSources.B2Headers;
 import com.backblaze.b2.client.contentSources.B2HeadersImpl;
+import com.backblaze.b2.client.exceptions.B2BadRequestException;
 import com.backblaze.b2.client.exceptions.B2Exception;
 import com.backblaze.b2.client.exceptions.B2LocalException;
 import com.backblaze.b2.client.exceptions.B2UnauthorizedException;
@@ -94,6 +95,12 @@ public class B2StorageClientWebifierImpl implements B2StorageClientWebifier {
     // it always ends with a '/'.
     private final String masterUrl;
     private final B2TestMode testModeOrNull;
+
+    /**
+     * Special chars allowed in header as defined by: https://tools.ietf.org/html/rfc7230#section-3.2.6
+     */
+    private static final char[] HEADER_SPECIAL_CHARS_RFC7230 = new char[] { '!', '#', '$', '%', '&', '\'', '*',
+            '+', '-', '.', '^', '_', '`', '|', '~' };
 
     public B2StorageClientWebifierImpl(B2WebApiClient webApiClient,
                                        String userAgent,
@@ -261,8 +268,11 @@ public class B2StorageClientWebifierImpl implements B2StorageClientWebifier {
             }
 
             // add any custom file infos.
-            // XXX: really percentEncode the keys?  maybe check for ok characters instead?
-            request.getFileInfo().forEach((k, v) -> headersBuilder.set(B2Headers.FILE_INFO_PREFIX + percentEncode(k), percentEncode(v)));
+            // Only percent encode the values.  Check the keys for legal characters
+            for (Map.Entry<String, String> entry : request.getFileInfo().entrySet()) {
+                validateFileInfoName(entry.getKey());
+                headersBuilder.set(B2Headers.FILE_INFO_PREFIX + entry.getKey(), percentEncode(entry.getValue()));
+            }
 
             final B2ByteProgressListener progressAdapter = new B2UploadProgressAdapter(uploadListener, 0, 1, 0, contentLen);
             final B2ByteProgressFilteringListener progressListener = new B2ByteProgressFilteringListener(progressAdapter);
@@ -676,5 +686,40 @@ public class B2StorageClientWebifierImpl implements B2StorageClientWebifier {
         }
 
         return countOfQueryParameters;
+    }
+
+    /**
+     * Validates whether each char in key is a valid header character according to RFC 7230:
+     * https://tools.ietf.org/html/rfc7230#section-3.2
+     *
+     * @param name The String to validate
+     * @throws B2BadRequestException if any of the characters are not valid
+     */
+    private void validateFileInfoName(String name) throws B2BadRequestException {
+
+        for (int i = 0; i < name.length(); i++) {
+            if (!isLegalInfoNameCharacter(name.charAt(i))) {
+                throw new B2BadRequestException(B2BadRequestException.DEFAULT_CODE,
+                        null,
+                        "Illegal file info name: " + name);
+            }
+        }
+    }
+
+    private boolean isLegalInfoNameCharacter(char c) {
+        return ('a' <= c && c <= 'z') ||
+                ('A' <= c && c <= 'Z') ||
+                ('0' <= c && c <= '9') ||
+                isRFC7230SpecialChar(c);
+    }
+
+    private boolean isRFC7230SpecialChar(char c) {
+        for (char specialChar : HEADER_SPECIAL_CHARS_RFC7230) {
+            if (c == specialChar) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/core/src/main/java/com/backblaze/b2/client/B2StorageClientWebifierImpl.java
+++ b/core/src/main/java/com/backblaze/b2/client/B2StorageClientWebifierImpl.java
@@ -700,6 +700,9 @@ public class B2StorageClientWebifierImpl implements B2StorageClientWebifier {
     }
 
     private boolean isLegalInfoNameCharacter(char c) {
+        /**
+         * Chars allowed in header as defined by: https://tools.ietf.org/html/rfc7230#section-3.2.6
+         */
         return
                 ('a' <= c && c <= 'z') ||
                 ('A' <= c && c <= 'Z') ||

--- a/core/src/main/java/com/backblaze/b2/client/contentSources/B2Headers.java
+++ b/core/src/main/java/com/backblaze/b2/client/contentSources/B2Headers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, Backblaze Inc. All Rights Reserved.
+ * Copyright 2020, Backblaze Inc. All Rights Reserved.
  * License https://www.backblaze.com/using_b2_code.html
  */
 package com.backblaze.b2.client.contentSources;
@@ -190,8 +190,8 @@ public interface B2Headers {
         for (String name : getNames()) {
             if (startsWithIgnoreCase(name, FILE_INFO_PREFIX)) {
                 final String shortName = name.substring(FILE_INFO_PREFIX.length());
-                // XXX the uploader encodes the name.  might as well decode here.
-                info.put(percentDecode(shortName), percentDecode(getValueOrNull(name)));
+                // The uploader no longer encodes the name, so only decode the value
+                info.put(shortName, percentDecode(getValueOrNull(name)));
             }
         }
         return info;

--- a/core/src/test/java/com/backblaze/b2/client/B2StorageClientWebifierImplTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2StorageClientWebifierImplTest.java
@@ -9,6 +9,7 @@ import com.backblaze.b2.client.contentSources.B2ByteArrayContentSource;
 import com.backblaze.b2.client.contentSources.B2ContentSource;
 import com.backblaze.b2.client.contentSources.B2ContentTypes;
 import com.backblaze.b2.client.contentSources.B2Headers;
+import com.backblaze.b2.client.exceptions.B2BadRequestException;
 import com.backblaze.b2.client.exceptions.B2Exception;
 import com.backblaze.b2.client.exceptions.B2UnauthorizedException;
 import com.backblaze.b2.client.structures.B2AccountAuthorization;
@@ -1514,5 +1515,15 @@ public class B2StorageClientWebifierImplTest extends B2BaseTest {
         public InputStream createInputStream() throws IOException, B2Exception {
             return nested.createInputStream();
         }
+    }
+
+    @Test
+    public void testValidateFileInfoNameThrowsForIllegalChars() throws B2BadRequestException {
+        final String nameWithIllegalChars = "my-header<>illegalChars()@";
+
+        thrown.expect(B2BadRequestException.class);
+        thrown.expectMessage("Illegal file info name: " + nameWithIllegalChars);
+
+        webifier.validateFileInfoName(nameWithIllegalChars);
     }
 }

--- a/core/src/test/java/com/backblaze/b2/client/B2StorageClientWebifierImplTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2StorageClientWebifierImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, Backblaze Inc. All Rights Reserved.
+ * Copyright 2020, Backblaze Inc. All Rights Reserved.
  * License https://www.backblaze.com/using_b2_code.html
  */
 package com.backblaze.b2.client;
@@ -80,6 +80,7 @@ import static com.backblaze.b2.client.exceptions.B2UnauthorizedException.Request
 import static com.backblaze.b2.client.exceptions.B2UnauthorizedException.RequestCategory.UPLOADING;
 import static com.backblaze.b2.json.B2Json.toJsonOrThrowRuntime;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.eq;
@@ -362,7 +363,7 @@ public class B2StorageClientWebifierImplTest extends B2BaseTest {
     @Test
     public void testDoesntAddExtraSlashAtEndOfMasterUrl() {
         //noinspection ConstantConditions
-        assertTrue(!MASTER_URL.endsWith("/"));
+        assertFalse(MASTER_URL.endsWith("/"));
 
         final B2StorageClientWebifierImpl ifier = new B2StorageClientWebifierImpl(
                 webApiClient,
@@ -370,7 +371,7 @@ public class B2StorageClientWebifierImplTest extends B2BaseTest {
                 MASTER_URL + "/",
                 null);
         assertTrue(ifier.getMasterUrl().endsWith("/"));
-        assertTrue(!ifier.getMasterUrl().endsWith("//"));
+        assertFalse(ifier.getMasterUrl().endsWith("//"));
     }
 
     @Test
@@ -888,7 +889,7 @@ public class B2StorageClientWebifierImplTest extends B2BaseTest {
         B2FileVersion version = webifier.getFileInfoByName(ACCOUNT_AUTH, request);
 
         Map<String, String> expectedFileInfo = new HashMap<>();
-        expectedFileInfo.put("Color", "gr\u00fcn");
+        expectedFileInfo.put("Color-with.special_chars`~!#$%^|\'*&+", "gr\u00fcn");
         expectedFileInfo.put("src_last_modified_millis", "1");
 
         assertEquals(fileId(1), version.getFileId());

--- a/core/src/test/java/com/backblaze/b2/client/B2TestHelpers.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2TestHelpers.java
@@ -193,7 +193,7 @@ public class B2TestHelpers {
                 .set(CONTENT_LENGTH, Integer.toString(i))
                 .set(UPLOAD_TIMESTAMP, Integer.toString(i))
                 .set(SRC_LAST_MODIFIED_MILLIS, Integer.toString(i))
-                .set(FILE_INFO_PREFIX + "Color", "gr%C3%BCn")
+                .set(FILE_INFO_PREFIX + "Color-with.special_chars`~!#$%^|\'*&+", "gr%C3%BCn")
                 .build();
     }
 


### PR DESCRIPTION
This PR validates against all supported chars in RFC 7230 https://tools.ietf.org/html/rfc7230#section-3.2

Testing: All tests