### PR TITLE
Fixes for the check_code python script and samples gradle file

### DIFF
--- a/check_code
+++ b/check_code
@@ -69,7 +69,7 @@ PREFIX = 'com.backblaze.b2.'
 
 def handle_args(argv):
     parser = argparse.ArgumentParser(description=USAGE)
-    parser.add_argument('directoriesOrFiles', nargs='*', help='The directories or files to check', default=["src/main"])
+    parser.add_argument('directoriesOrFiles', nargs='*', help='The directories or files to check', default=["core/src/main"])
     parsed_args = parser.parse_args()
     return parsed_args
 

--- a/common.gradle
+++ b/common.gradle
@@ -24,7 +24,7 @@ repositories {
 }
 
 ext.readVersion = { ->
-    BufferedReader reader = new BufferedReader(new FileReader("core/src/main/resources/b2-sdk-core/version.txt"));
+    BufferedReader reader = new BufferedReader(new FileReader(new File(rootProject.projectDir, "core/src/main/resources/b2-sdk-core/version.txt")))
     String version = reader.readLine().trim()
     if (version.isEmpty()) {
         throw new RuntimeException("version is empty!?")
@@ -71,7 +71,7 @@ artifacts {
 // enough (less than a second) that i'm not going to try to avoid
 // running it.
 task checkCode(type: Exec) {
-    commandLine "python", "../check_code"
+    commandLine "python", "../check_code", "src/main"
 }
 classes.dependsOn checkCode
 


### PR DESCRIPTION
This update fixes the check_code python script so its default parameters work when executing it directly in-place like this:

   ./check_code

Also updates the common.gradle script to pass the desired path name based on its current working directory of `./core` and to successfully read the version.txt file when used from the ./samples/build.gradle script.