### PR TITLE
Fix regular expression that has an unescaped

### DIFF
--- a/check_code
+++ b/check_code
@@ -37,8 +37,8 @@ IN_LIB_RE = re.compile("/lib/[^/]+$")
 #
 ########################
 
-COPYRIGHT_RE = re.compile("Copyright 20[12][0-9], Backblaze Inc. All Rights Reserved.")
-LICENSE_RE = re.compile("License https://www.backblaze.com/using_b2_code.html")
+COPYRIGHT_RE = re.compile("Copyright 20[12][0-9], Backblaze Inc\. All Rights Reserved.")
+LICENSE_RE = re.compile("License https://www\.backblaze\.com/using_b2_code\.html")
 
 # how many lines at the top of a file should we look at?
 NUMBER_OF_LINES_TO_EXAMINE = 10


### PR DESCRIPTION
This regular expression has an unescaped `.`, so it might match more hosts than expected. For example, this lines below will show LGTM.

```python
######################################################################
#
# File: check_licenses
#
# Copyright 2017, Backblaze Incx All Rights Reserved.
#
# License https://wwwxbackblazexcom/using_b2_codexhtml
#
######################################################################
```

```bash
> ./check_code check_code
check_code: looks good.
```