### PR TITLE
Use Python 3.6 for scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,11 @@ env:
     - OUTPUT_ZIP=b2-sdk-build-${TRAVIS_BUILD_NUMBER}.zip
 
 before_install:
+  - pyenv global 3.6
   - mkdir -p ~/.gradle && echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties
-  - sudo pip install b2
+  - python3 -m pip install b2
+  - which python3
+  - echo PATH=$PATH
 
 script:
   #

--- a/maybe_upload_build_results
+++ b/maybe_upload_build_results
@@ -34,8 +34,14 @@ fi
 
 DEST=builds/$ZIP_TO_UPLOAD
 
+if test -z "$B2_UPLOAD_BUCKET"; then
+    # no B2_UPLOAD_BUCKET was defined, so use the default
+    B2_UPLOAD_BUCKET=the-b2-sdk-java
+    echo "using default bucket $B2_UPLOAD_BUCKET"
+fi
+
 echo authorizing account
-b2 authorize_account $B2_ACCOUNT_ID $B2_APPLICATION_KEY
+python3 b2 authorize_account $B2_ACCOUNT_ID $B2_APPLICATION_KEY
 status=$?
 if test $status != "0"; then
     echo "failed to authorize with b2 server"
@@ -43,8 +49,8 @@ if test $status != "0"; then
 fi
 
 
-echo uploading $SRC
-b2 upload_file --contentType application/octet the-b2-sdk-java $SRC $DEST
+echo uploading $SRC to $B2_UPLOAD_BUCKET
+python3 b2 upload_file --contentType application/octet $B2_UPLOAD_BUCKET $SRC $DEST
 status=$?
 if test $status != "0"; then
     echo "failed to upload $SRC to b2"


### PR DESCRIPTION
Update to use Python 3.6 instead of Python 2.7 for Travis-CI.