### PR TITLE
upgrade setuptools and pip before installing B2 CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ env:
 
 before_install:
   - mkdir -p ~/.gradle && echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties
-  - pip3 install "setuptools_scm[toml]<6.0"
+  # upgrade pip and setuptools so that b2 CLI can be properly installed
+  - pip3 install -U pip setuptools
   - pip3 install b2
 
 script:


### PR DESCRIPTION
Following suggestion from b2 sdk python team, upgrade setuptools and pip prior to installing B2 CLI instead of calling `pip3 install "setuptools_scm[toml]<6.0"`

Jira: https://backblaze.atlassian.net/browse/DEV-8602