### PR TITLE
change getBucketOrNullByName to request specific bucket by name

### DIFF
--- a/core/src/main/java/com/backblaze/b2/client/B2StorageClient.java
+++ b/core/src/main/java/com/backblaze/b2/client/B2StorageClient.java
@@ -48,7 +48,6 @@ import com.backblaze.b2.client.structures.B2UploadFileRequest;
 import com.backblaze.b2.client.structures.B2UploadListener;
 import com.backblaze.b2.client.structures.B2UploadPartUrlResponse;
 import com.backblaze.b2.client.structures.B2UploadUrlResponse;
-import com.backblaze.b2.util.B2Preconditions;
 
 import java.io.Closeable;
 import java.util.List;
@@ -203,12 +202,11 @@ public interface B2StorageClient extends Closeable {
      * @throws B2Exception if there's any trouble.
      */
     default B2Bucket getBucketOrNullByName(String name) throws B2Exception {
-        for (B2Bucket bucket : buckets()) {
-            if (bucket.getBucketName().equals(name)) {
-                return bucket;
-            }
-        }
-        return null;
+        // see note above in listBuckets() regarding retries and calling getAccountId()
+        final String accountId = getAccountId();
+        final B2ListBucketsRequest request = B2ListBucketsRequest.builder(accountId).setBucketName(name).build();
+        final List<B2Bucket> buckets = listBuckets(request).getBuckets();
+        return buckets.isEmpty() ? null : buckets.get(0);
     }
 
     /**

--- a/core/src/test/java/com/backblaze/b2/client/B2StorageClientImplTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2StorageClientImplTest.java
@@ -365,6 +365,7 @@ public class B2StorageClientImplTest extends B2BaseTest {
     public void testGetBucketByName() throws B2Exception {
         final B2ListBucketsRequest expectedRequest = B2ListBucketsRequest
                 .builder(ACCOUNT_ID)
+                .setBucketName(BUCKET_NAME)
                 .build();
         final B2ListBucketsResponse response = new B2ListBucketsResponse(
                 listOf(bucket(1))
@@ -372,6 +373,15 @@ public class B2StorageClientImplTest extends B2BaseTest {
         when(webifier.listBuckets(ACCOUNT_AUTH, expectedRequest)).thenReturn(response);
 
         assertEquals(bucket(1), client.getBucketOrNullByName(BUCKET_NAME));
+
+        final String noSuchBucketName = "noSuchBucket";
+        final B2ListBucketsRequest expectedNoSuchBucketRequest = B2ListBucketsRequest
+                .builder(ACCOUNT_ID)
+                .setBucketName(noSuchBucketName)
+                .build();
+        final B2ListBucketsResponse noSuchBucketResponse = new B2ListBucketsResponse(Collections.emptyList());
+        when(webifier.listBuckets(ACCOUNT_AUTH, expectedNoSuchBucketRequest)).thenReturn(noSuchBucketResponse);
+
         assertNull(client.getBucketOrNullByName("noSuchBucket"));
     }
 


### PR DESCRIPTION
The default implementation B2StorageClient::getBucketOrNullByName() fails if the app key capability only has listBuckets capability for a single bucket because it uses listBuckets() and then iterates through all the bucket names. Needs to be changed to instead use B2ListBucketsRequest to specify the bucket name.

Reported in #151

Testing: unit tests