### PR TITLE
Updates B2WebApiHttpClientImpl to return a subtype of B2Exception on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased] - TBD
+### Added
+* Return a subtype of `B2Exception` on errors when the response body does not conform to `B2ErrorStructure`. 
+  Returning a `B2Exception` subtype enables the `B2Retryer` to retry exceptions the may succeed on retry.
+
 ## [6.1.0] - 2022-09-19
 ### Added
 * Added support for Java 8's `-parameters` option so constructor parameters do not need to be reiterated in `B2Json.constructor#params`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased] - TBD
 ### Added
 * Return a subtype of `B2Exception` on errors when the response body does not conform to `B2ErrorStructure`. 
-  Returning a `B2Exception` subtype enables the `B2Retryer` to retry exceptions the may succeed on retry.
+  Returning a `B2Exception` subtype enables the `B2Retryer` to retry exceptions that may succeed on retry.
 
 ## [6.1.0] - 2022-09-19
 ### Added

--- a/httpclient/src/main/java/com/backblaze/b2/client/webApiHttpClient/B2WebApiHttpClientImpl.java
+++ b/httpclient/src/main/java/com/backblaze/b2/client/webApiHttpClient/B2WebApiHttpClientImpl.java
@@ -284,11 +284,11 @@ public class B2WebApiHttpClientImpl implements B2WebApiClient {
         try {
             B2ErrorStructure err = B2Json.get().fromJson(responseText, B2ErrorStructure.class);
             return B2Exception.create(err.code, err.status, getRetryAfterSecondsOrNull(response), err.message);
-        }
-        catch (Throwable t) {
+        } catch (Throwable t) {
             // we can't parse the response as a B2 JSON error structure.
-            // so use the default.
-            return new B2Exception("unknown", statusCode, getRetryAfterSecondsOrNull(response), responseText);
+            // so use the "unknown" as the code
+            return B2Exception.create("unknown", statusCode, getRetryAfterSecondsOrNull(response), responseText);
+
         }
     }
 


### PR DESCRIPTION
If the error text is not of type `B2ErrorStructure`, then attempt to return a subtype of B2Exception. Returning a B2Exception subtype enables the `B2Retryer` to retry calls that may succeed on retry.