### PR TITLE
STORAGE-2798 Updated B2StorageClientWebifierImpl methods to improve extensibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 ## [Unreleased] - TBD
+### Changed
+Updated `downloadByName()` and `downloadById()` to use their respective `getDownloadByNameUrl()` and 
+`getDownloadByIdUrl()` methods for improved extensibility 
+
 ## [6.3.0] - 2024-11-08
 ### Added
 * Fixed `B2StorageClient.deleteAllFilesInBucket` so it uses `fileVersions` instead of `fileNames`.

--- a/core/src/main/java/com/backblaze/b2/client/B2StorageClientWebifierImpl.java
+++ b/core/src/main/java/com/backblaze/b2/client/B2StorageClientWebifierImpl.java
@@ -488,7 +488,7 @@ public class B2StorageClientWebifierImpl implements B2StorageClientWebifier {
                              B2DownloadByIdRequest request,
                              B2ContentSink handler) throws B2Exception {
         downloadGuts(accountAuth,
-                makeDownloadByIdUrl(accountAuth, request),
+                getDownloadByIdUrl(accountAuth, request),
                 request.getRange(),
                 request.getServerSideEncryption(),
                 handler);
@@ -505,7 +505,7 @@ public class B2StorageClientWebifierImpl implements B2StorageClientWebifier {
                                B2DownloadByNameRequest request,
                                B2ContentSink handler) throws B2Exception {
         downloadGuts(accountAuth,
-                makeDownloadByNameUrl(accountAuth, request.getBucketName(), request.getFileName(), request),
+                getDownloadByNameUrl(accountAuth, request),
                 request.getRange(),
                 request.getServerSideEncryption(),
                 handler);

--- a/core/src/test/java/com/backblaze/b2/client/B2StorageClientWebifierImplTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2StorageClientWebifierImplTest.java
@@ -103,6 +103,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -1190,7 +1191,9 @@ public class B2StorageClientWebifierImplTest extends B2BaseTest {
         final B2DownloadByIdRequest request = B2DownloadByIdRequest
                 .builder(fileId(1))
                 .build();
-        webifier.downloadById(ACCOUNT_AUTH, request, noopContentHandler);
+        final B2StorageClientWebifierImpl webifierSpy = spy(webifier);
+        webifierSpy.downloadById(ACCOUNT_AUTH, request, noopContentHandler);
+        verify(webifierSpy).getDownloadByIdUrl(ACCOUNT_AUTH, request);
 
         webApiClient.check("getContent.\n" +
                 "url:\n" +
@@ -1201,7 +1204,7 @@ public class B2StorageClientWebifierImplTest extends B2BaseTest {
                 "    X-Bz-Test-Mode: force_cap_exceeded\n"
         );
 
-        assertEquals(expectedUrl, webifier.getDownloadByIdUrl(ACCOUNT_AUTH, request));
+        assertEquals(expectedUrl, webifierSpy.getDownloadByIdUrl(ACCOUNT_AUTH, request));
 
         checkRequestCategory(OTHER, w -> w.downloadById(ACCOUNT_AUTH, request, noopContentHandler));
     }
@@ -1303,7 +1306,9 @@ public class B2StorageClientWebifierImplTest extends B2BaseTest {
         final B2DownloadByNameRequest request = B2DownloadByNameRequest
                 .builder(bucketName(1), fileName(1))
                 .build();
-        webifier.downloadByName(ACCOUNT_AUTH, request, noopContentHandler);
+        final B2StorageClientWebifierImpl webifierSpy = spy(webifier);
+        webifierSpy.downloadByName(ACCOUNT_AUTH, request, noopContentHandler);
+        verify(webifierSpy).getDownloadByNameUrl(ACCOUNT_AUTH, request);
 
         webApiClient.check("getContent.\n" +
                 "url:\n" +
@@ -1313,7 +1318,7 @@ public class B2StorageClientWebifierImplTest extends B2BaseTest {
                 "    User-Agent: SecretAgentMan/3.19.28\n" +
                 "    X-Bz-Test-Mode: force_cap_exceeded\n"
         );
-        assertEquals(expectedUrl, webifier.getDownloadByNameUrl(ACCOUNT_AUTH, request));
+        assertEquals(expectedUrl, webifierSpy.getDownloadByNameUrl(ACCOUNT_AUTH, request));
 
         checkRequestCategory(OTHER, w -> w.downloadByName(ACCOUNT_AUTH, request, noopContentHandler));
     }

--- a/core/src/test/java/com/backblaze/b2/client/B2StorageClientWebifierImplTest.java
+++ b/core/src/test/java/com/backblaze/b2/client/B2StorageClientWebifierImplTest.java
@@ -1204,7 +1204,7 @@ public class B2StorageClientWebifierImplTest extends B2BaseTest {
                 "    X-Bz-Test-Mode: force_cap_exceeded\n"
         );
 
-        assertEquals(expectedUrl, webifierSpy.getDownloadByIdUrl(ACCOUNT_AUTH, request));
+        assertEquals(expectedUrl, webifier.getDownloadByIdUrl(ACCOUNT_AUTH, request));
 
         checkRequestCategory(OTHER, w -> w.downloadById(ACCOUNT_AUTH, request, noopContentHandler));
     }
@@ -1318,7 +1318,7 @@ public class B2StorageClientWebifierImplTest extends B2BaseTest {
                 "    User-Agent: SecretAgentMan/3.19.28\n" +
                 "    X-Bz-Test-Mode: force_cap_exceeded\n"
         );
-        assertEquals(expectedUrl, webifierSpy.getDownloadByNameUrl(ACCOUNT_AUTH, request));
+        assertEquals(expectedUrl, webifier.getDownloadByNameUrl(ACCOUNT_AUTH, request));
 
         checkRequestCategory(OTHER, w -> w.downloadByName(ACCOUNT_AUTH, request, noopContentHandler));
     }


### PR DESCRIPTION
Updated `downloadByName()` and `downloadById()` to use their respective `getDownloadByNameUrl()` and 
`getDownloadByIdUrl()` methods for improved extensibility 