### PR TITLE
Update to use latest version of sonatype/nexus plugin

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,8 +31,8 @@ jobs:
           RELEASE_BUILD: true
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
-          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_TOKEN_USERNAME }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_TOKEN_PASSWORD }}
 
       - name: Get tag name
         id: get_tag

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,13 +2,17 @@
 // License https://www.backblaze.com/using_b2_code.html
 
 plugins {
-    id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
+    id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
 }
 
 nexusPublishing {
     repositories {
+        sonatype()
+    }
+    repositories {
         sonatype {
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+            // see https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,9 +7,6 @@ plugins {
 
 nexusPublishing {
     repositories {
-        sonatype()
-    }
-    repositories {
         sonatype {
             // see https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration
             nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))


### PR DESCRIPTION
New version of the nexus publish plugin is released which is what we need to use to publish to the maven central repository. This PR updates it to use the new publishing URL and updates the credentials to follow what was mentioned here https://github.com/gradle-nexus/publish-plugin